### PR TITLE
Declare type for string in C++ procedural variables

### DIFF
--- a/software_architecture_and_design/procedural/variables_cpp.md
+++ b/software_architecture_and_design/procedural/variables_cpp.md
@@ -237,7 +237,7 @@ int main() {
     std::string given = "Joe";
     std::string middle = "Frederick";
     std::string family = "\'Bloggs\'";
-    full = given + " " + middle + " " + family;
+    std::string full = given + " " + middle + " " + family;
     std::cout << full << std::endl;
 }
 ~~~


### PR DESCRIPTION
Without the type declaration for full, this code throws an error