### PR TITLE
Fix descriptions

### DIFF
--- a/libraries/index.md
+++ b/libraries/index.md
@@ -5,7 +5,8 @@ courses: [
   pybamm,
   pybamm-developer,
 ]
-summary: Courses on using individual libraries.
+summary: |
+  Courses on using individual libraries.
 ---
 
 Courses on using individual libraries.

--- a/scientific_computing/index.md
+++ b/scientific_computing/index.md
@@ -9,7 +9,8 @@ courses: [
   ode_solvers,
   bayesian_inference,
 ]
-summary: Courses on scientific computing on subjects including linear algebra, ode solving, bayesian statistics etc.
+summary: |
+  Courses on scientific computing on subjects including linear algebra, ode solving, bayesian statistics etc.
 ---
 
 Courses on scientific computing on subjects including linear algebra, ode solving, bayesian statistics etc.

--- a/technology_and_tooling/index.md
+++ b/technology_and_tooling/index.md
@@ -12,7 +12,7 @@ courses: [
   snakemake,
 ]
 summary: |
-  Programming design concepts and patterns, such as proceedural, object-orientated, functional, generic. Covers data structures, memory allocation, ownership.
+  Basic tools like bash, version control, containers, IDEs, and snakemake.
 ---
 
-Programming design concepts and patterns, such as proceedural, object-orientated, functional, generic. Covers data structures, memory allocation, ownership.
+Basic tools like bash, version control, containers, IDEs, and snakemake.


### PR DESCRIPTION
About
---

Closes #93 

- The descriptions for two of the themes were not appearing. The problem seems to be that the summaries need to be specified as multi-line strings (even though they are a single line). This is a small fix to make the summaries appear, it does not tackle why single line strings need to be specified as multiply strings 😅 
- The tech & tooling and software architecture themes had the same description, so I've updated the tech & tooling one.