### PR TITLE
correct solution to reduce(data, lambda a,b: a*b)

### DIFF
--- a/software_architecture_and_design/functional/higher_order_functions_python.md
+++ b/software_architecture_and_design/functional/higher_order_functions_python.md
@@ -106,7 +106,7 @@ print(reduce(data, lambda a, b: min(a, b)))
 
 ```
 9
--24
+0
 4
 -1
 ```


### PR DESCRIPTION
result is set to 0 in the custom reduce function, so multiplying it with the values in the list 'data' should always return 0