### PR TITLE
fix invalid yaml related to citations

### DIFF
--- a/scientific_computing/bayesian_inference/01-AM.md
+++ b/scientific_computing/bayesian_inference/01-AM.md
@@ -4,15 +4,14 @@ dependsOn: [
 ]
 tags: []
 attribution: 
-  - citation: This material has been adapted from material by Ben Lambert from the "Scientific Computing" module of the SABS R³ Center for Doctoral Training.
-    url: https://www.sabsr3.ox.ac.uk
-    image: https://www.sabsr3.ox.ac.uk/sites/default/files/styles/site_logo/public/styles/site_logo/public/sabsr3/site-logo/sabs_r3_cdt_logo_v3_111x109.png
-    license: CC-BY-4.0
-  - citation: This course material was developed as part of UNIVERSE-HPC, which is funded through the SPF ExCALIBUR programme under grant number EP/W035731/1 
-    url: https://www.universe-hpc.ac.uk
-    image: https://www.universe-hpc.ac.uk/assets/images/universe-hpc.png
-    license: CC-BY-4.0
-
+- citation: This material has been adapted from material by Ben Lambert from the "Scientific Computing" module of the SABS R³ Center for Doctoral Training.
+  url: https://www.sabsr3.ox.ac.uk
+  image: https://www.sabsr3.ox.ac.uk/sites/default/files/styles/site_logo/public/styles/site_logo/public/sabsr3/site-logo/sabs_r3_cdt_logo_v3_111x109.png
+  license: CC-BY-4.0
+- citation: This course material was developed as part of UNIVERSE-HPC, which is funded through the SPF ExCALIBUR programme under grant number EP/W035731/1 
+  url: https://www.universe-hpc.ac.uk
+  image: https://www.universe-hpc.ac.uk/assets/images/universe-hpc.png
+  license: CC-BY-4.0
 
 ---
 

--- a/scientific_computing/bayesian_inference/02-PM.md
+++ b/scientific_computing/bayesian_inference/02-PM.md
@@ -6,14 +6,13 @@ dependsOn: [
 tags: []
 attribution: 
 - citation: This material has been adapted from material by Ben Lambert from the "Scientific Computing" module of the SABS R³ Center for Doctoral Training.
-    url: https://www.sabsr3.ox.ac.uk
-    image: https://www.sabsr3.ox.ac.uk/sites/default/files/styles/site_logo/public/styles/site_logo/public/sabsr3/site-logo/sabs_r3_cdt_logo_v3_111x109.png
-    license: CC-BY-4.0
-  - citation: This course material was developed as part of UNIVERSE-HPC, which is funded through the SPF ExCALIBUR programme under grant number EP/W035731/1 
-    url: https://www.universe-hpc.ac.uk
-    image: https://www.universe-hpc.ac.uk/assets/images/universe-hpc.png
-    license: CC-BY-4.0
-
+  url: https://www.sabsr3.ox.ac.uk
+  image: https://www.sabsr3.ox.ac.uk/sites/default/files/styles/site_logo/public/styles/site_logo/public/sabsr3/site-logo/sabs_r3_cdt_logo_v3_111x109.png
+  license: CC-BY-4.0
+- citation: This course material was developed as part of UNIVERSE-HPC, which is funded through the SPF ExCALIBUR programme under grant number EP/W035731/1 
+  url: https://www.universe-hpc.ac.uk
+  image: https://www.universe-hpc.ac.uk/assets/images/universe-hpc.png
+  license: CC-BY-4.0
 
 ---
 

--- a/scientific_computing/bayesian_inference/index.md
+++ b/scientific_computing/bayesian_inference/index.md
@@ -9,14 +9,14 @@ files: [
   02-PM.md,
 ]
 attribution: 
-  - citation: This material has been adapted from material by Ben Lambert from the "Scientific Computing" module of the SABS R³ Center for Doctoral Training.
-    url: https://www.sabsr3.ox.ac.uk
-    image: https://www.sabsr3.ox.ac.uk/sites/default/files/styles/site_logo/public/styles/site_logo/public/sabsr3/site-logo/sabs_r3_cdt_logo_v3_111x109.png
-    license: CC-BY-4.0
-  - citation: This course material was developed as part of UNIVERSE-HPC, which is funded through the SPF ExCALIBUR programme under grant number EP/W035731/1 
-    url: https://www.universe-hpc.ac.uk
-    image: https://www.universe-hpc.ac.uk/assets/images/universe-hpc.png
-    license: CC-BY-4.0
+- citation: This material has been adapted from material by Ben Lambert from the "Scientific Computing" module of the SABS R³ Center for Doctoral Training.
+  url: https://www.sabsr3.ox.ac.uk
+  image: https://www.sabsr3.ox.ac.uk/sites/default/files/styles/site_logo/public/styles/site_logo/public/sabsr3/site-logo/sabs_r3_cdt_logo_v3_111x109.png
+  license: CC-BY-4.0
+- citation: This course material was developed as part of UNIVERSE-HPC, which is funded through the SPF ExCALIBUR programme under grant number EP/W035731/1 
+  url: https://www.universe-hpc.ac.uk
+  image: https://www.universe-hpc.ac.uk/assets/images/universe-hpc.png
+  license: CC-BY-4.0
 
 
 ---

--- a/scientific_computing/essential_maths/01_graphs.md
+++ b/scientific_computing/essential_maths/01_graphs.md
@@ -5,13 +5,13 @@ dependsOn: [
 tags: []
 attribution: 
 - citation: This material has been adapted from material by Fergus Cooper from the "Essential Mathematics" module of the SABS R³ Center for Doctoral Training.
-    url: https://www.sabsr3.ox.ac.uk
-    image: https://www.sabsr3.ox.ac.uk/sites/default/files/styles/site_logo/public/styles/site_logo/public/sabsr3/site-logo/sabs_r3_cdt_logo_v3_111x109.png
-    license: CC-BY-4.0
-  - citation: This course material was developed as part of UNIVERSE-HPC, which is funded through the SPF ExCALIBUR programme under grant number EP/W035731/1 
-    url: https://www.universe-hpc.ac.uk
-    image: https://www.universe-hpc.ac.uk/assets/images/universe-hpc.png
-    license: CC-BY-4.0
+  url: https://www.sabsr3.ox.ac.uk
+  image: https://www.sabsr3.ox.ac.uk/sites/default/files/styles/site_logo/public/styles/site_logo/public/sabsr3/site-logo/sabs_r3_cdt_logo_v3_111x109.png
+  license: CC-BY-4.0
+- citation: This course material was developed as part of UNIVERSE-HPC, which is funded through the SPF ExCALIBUR programme under grant number EP/W035731/1 
+  url: https://www.universe-hpc.ac.uk
+  image: https://www.universe-hpc.ac.uk/assets/images/universe-hpc.png
+  license: CC-BY-4.0
 
 ---
 

--- a/scientific_computing/essential_maths/02_indices_and_logs.md
+++ b/scientific_computing/essential_maths/02_indices_and_logs.md
@@ -6,13 +6,13 @@ dependsOn: [
 tags: []
 attribution: 
 - citation: This material has been adapted from material by Fergus Cooper from the "Essential Mathematics" module of the SABS R³ Center for Doctoral Training.
-    url: https://www.sabsr3.ox.ac.uk
-    image: https://www.sabsr3.ox.ac.uk/sites/default/files/styles/site_logo/public/styles/site_logo/public/sabsr3/site-logo/sabs_r3_cdt_logo_v3_111x109.png
-    license: CC-BY-4.0
-  - citation: This course material was developed as part of UNIVERSE-HPC, which is funded through the SPF ExCALIBUR programme under grant number EP/W035731/1 
-    url: https://www.universe-hpc.ac.uk
-    image: https://www.universe-hpc.ac.uk/assets/images/universe-hpc.png
-    license: CC-BY-4.0
+  url: https://www.sabsr3.ox.ac.uk
+  image: https://www.sabsr3.ox.ac.uk/sites/default/files/styles/site_logo/public/styles/site_logo/public/sabsr3/site-logo/sabs_r3_cdt_logo_v3_111x109.png
+  license: CC-BY-4.0
+- citation: This course material was developed as part of UNIVERSE-HPC, which is funded through the SPF ExCALIBUR programme under grant number EP/W035731/1 
+  url: https://www.universe-hpc.ac.uk
+  image: https://www.universe-hpc.ac.uk/assets/images/universe-hpc.png
+  license: CC-BY-4.0
 
 ---
 

--- a/scientific_computing/essential_maths/03_differentiation_1.md
+++ b/scientific_computing/essential_maths/03_differentiation_1.md
@@ -6,13 +6,13 @@ dependsOn: [
 tags: []
 attribution: 
 - citation: This material has been adapted from material by Fergus Cooper from the "Essential Mathematics" module of the SABS R³ Center for Doctoral Training.
-    url: https://www.sabsr3.ox.ac.uk
-    image: https://www.sabsr3.ox.ac.uk/sites/default/files/styles/site_logo/public/styles/site_logo/public/sabsr3/site-logo/sabs_r3_cdt_logo_v3_111x109.png
-    license: CC-BY-4.0
-  - citation: This course material was developed as part of UNIVERSE-HPC, which is funded through the SPF ExCALIBUR programme under grant number EP/W035731/1 
-    url: https://www.universe-hpc.ac.uk
-    image: https://www.universe-hpc.ac.uk/assets/images/universe-hpc.png
-    license: CC-BY-4.0
+  url: https://www.sabsr3.ox.ac.uk
+  image: https://www.sabsr3.ox.ac.uk/sites/default/files/styles/site_logo/public/styles/site_logo/public/sabsr3/site-logo/sabs_r3_cdt_logo_v3_111x109.png
+  license: CC-BY-4.0
+- citation: This course material was developed as part of UNIVERSE-HPC, which is funded through the SPF ExCALIBUR programme under grant number EP/W035731/1 
+  url: https://www.universe-hpc.ac.uk
+  image: https://www.universe-hpc.ac.uk/assets/images/universe-hpc.png
+  license: CC-BY-4.0
 
 ---
 

--- a/scientific_computing/essential_maths/04_differentiation_2.md
+++ b/scientific_computing/essential_maths/04_differentiation_2.md
@@ -6,13 +6,13 @@ dependsOn: [
 tags: []
 attribution: 
 - citation: This material has been adapted from material by Fergus Cooper from the "Essential Mathematics" module of the SABS R³ Center for Doctoral Training.
-    url: https://www.sabsr3.ox.ac.uk
-    image: https://www.sabsr3.ox.ac.uk/sites/default/files/styles/site_logo/public/styles/site_logo/public/sabsr3/site-logo/sabs_r3_cdt_logo_v3_111x109.png
-    license: CC-BY-4.0
-  - citation: This course material was developed as part of UNIVERSE-HPC, which is funded through the SPF ExCALIBUR programme under grant number EP/W035731/1 
-    url: https://www.universe-hpc.ac.uk
-    image: https://www.universe-hpc.ac.uk/assets/images/universe-hpc.png
-    license: CC-BY-4.0
+  url: https://www.sabsr3.ox.ac.uk
+  image: https://www.sabsr3.ox.ac.uk/sites/default/files/styles/site_logo/public/styles/site_logo/public/sabsr3/site-logo/sabs_r3_cdt_logo_v3_111x109.png
+  license: CC-BY-4.0
+- citation: This course material was developed as part of UNIVERSE-HPC, which is funded through the SPF ExCALIBUR programme under grant number EP/W035731/1 
+  url: https://www.universe-hpc.ac.uk
+  image: https://www.universe-hpc.ac.uk/assets/images/universe-hpc.png
+  license: CC-BY-4.0
 
 ---
 

--- a/scientific_computing/essential_maths/05_differentiation_3.md
+++ b/scientific_computing/essential_maths/05_differentiation_3.md
@@ -6,13 +6,13 @@ dependsOn: [
 tags: []
 attribution: 
 - citation: This material has been adapted from material by Fergus Cooper from the "Essential Mathematics" module of the SABS R³ Center for Doctoral Training.
-    url: https://www.sabsr3.ox.ac.uk
-    image: https://www.sabsr3.ox.ac.uk/sites/default/files/styles/site_logo/public/styles/site_logo/public/sabsr3/site-logo/sabs_r3_cdt_logo_v3_111x109.png
-    license: CC-BY-4.0
-  - citation: This course material was developed as part of UNIVERSE-HPC, which is funded through the SPF ExCALIBUR programme under grant number EP/W035731/1 
-    url: https://www.universe-hpc.ac.uk
-    image: https://www.universe-hpc.ac.uk/assets/images/universe-hpc.png
-    license: CC-BY-4.0
+  url: https://www.sabsr3.ox.ac.uk
+  image: https://www.sabsr3.ox.ac.uk/sites/default/files/styles/site_logo/public/styles/site_logo/public/sabsr3/site-logo/sabs_r3_cdt_logo_v3_111x109.png
+  license: CC-BY-4.0
+- citation: This course material was developed as part of UNIVERSE-HPC, which is funded through the SPF ExCALIBUR programme under grant number EP/W035731/1 
+  url: https://www.universe-hpc.ac.uk
+  image: https://www.universe-hpc.ac.uk/assets/images/universe-hpc.png
+  license: CC-BY-4.0
 
 ---
 

--- a/scientific_computing/essential_maths/06_integration_1.md
+++ b/scientific_computing/essential_maths/06_integration_1.md
@@ -6,13 +6,13 @@ dependsOn: [
 tags: []
 attribution: 
 - citation: This material has been adapted from material by Fergus Cooper from the "Essential Mathematics" module of the SABS R³ Center for Doctoral Training.
-    url: https://www.sabsr3.ox.ac.uk
-    image: https://www.sabsr3.ox.ac.uk/sites/default/files/styles/site_logo/public/styles/site_logo/public/sabsr3/site-logo/sabs_r3_cdt_logo_v3_111x109.png
-    license: CC-BY-4.0
-  - citation: This course material was developed as part of UNIVERSE-HPC, which is funded through the SPF ExCALIBUR programme under grant number EP/W035731/1 
-    url: https://www.universe-hpc.ac.uk
-    image: https://www.universe-hpc.ac.uk/assets/images/universe-hpc.png
-    license: CC-BY-4.0
+  url: https://www.sabsr3.ox.ac.uk
+  image: https://www.sabsr3.ox.ac.uk/sites/default/files/styles/site_logo/public/styles/site_logo/public/sabsr3/site-logo/sabs_r3_cdt_logo_v3_111x109.png
+  license: CC-BY-4.0
+- citation: This course material was developed as part of UNIVERSE-HPC, which is funded through the SPF ExCALIBUR programme under grant number EP/W035731/1 
+  url: https://www.universe-hpc.ac.uk
+  image: https://www.universe-hpc.ac.uk/assets/images/universe-hpc.png
+  license: CC-BY-4.0
 
 ---
 

--- a/scientific_computing/essential_maths/07_integration_2.md
+++ b/scientific_computing/essential_maths/07_integration_2.md
@@ -6,13 +6,13 @@ dependsOn: [
 tags: []
 attribution: 
 - citation: This material has been adapted from material by Fergus Cooper from the "Essential Mathematics" module of the SABS R³ Center for Doctoral Training.
-    url: https://www.sabsr3.ox.ac.uk
-    image: https://www.sabsr3.ox.ac.uk/sites/default/files/styles/site_logo/public/styles/site_logo/public/sabsr3/site-logo/sabs_r3_cdt_logo_v3_111x109.png
-    license: CC-BY-4.0
-  - citation: This course material was developed as part of UNIVERSE-HPC, which is funded through the SPF ExCALIBUR programme under grant number EP/W035731/1 
-    url: https://www.universe-hpc.ac.uk
-    image: https://www.universe-hpc.ac.uk/assets/images/universe-hpc.png
-    license: CC-BY-4.0
+  url: https://www.sabsr3.ox.ac.uk
+  image: https://www.sabsr3.ox.ac.uk/sites/default/files/styles/site_logo/public/styles/site_logo/public/sabsr3/site-logo/sabs_r3_cdt_logo_v3_111x109.png
+  license: CC-BY-4.0
+- citation: This course material was developed as part of UNIVERSE-HPC, which is funded through the SPF ExCALIBUR programme under grant number EP/W035731/1 
+  url: https://www.universe-hpc.ac.uk
+  image: https://www.universe-hpc.ac.uk/assets/images/universe-hpc.png
+  license: CC-BY-4.0
 
 ---
 

--- a/scientific_computing/essential_maths/08_complex_numbers.md
+++ b/scientific_computing/essential_maths/08_complex_numbers.md
@@ -6,13 +6,13 @@ dependsOn: [
 tags: []
 attribution: 
 - citation: This material has been adapted from material by Fergus Cooper from the "Essential Mathematics" module of the SABS R³ Center for Doctoral Training.
-    url: https://www.sabsr3.ox.ac.uk
-    image: https://www.sabsr3.ox.ac.uk/sites/default/files/styles/site_logo/public/styles/site_logo/public/sabsr3/site-logo/sabs_r3_cdt_logo_v3_111x109.png
-    license: CC-BY-4.0
-  - citation: This course material was developed as part of UNIVERSE-HPC, which is funded through the SPF ExCALIBUR programme under grant number EP/W035731/1 
-    url: https://www.universe-hpc.ac.uk
-    image: https://www.universe-hpc.ac.uk/assets/images/universe-hpc.png
-    license: CC-BY-4.0
+  url: https://www.sabsr3.ox.ac.uk
+  image: https://www.sabsr3.ox.ac.uk/sites/default/files/styles/site_logo/public/styles/site_logo/public/sabsr3/site-logo/sabs_r3_cdt_logo_v3_111x109.png
+  license: CC-BY-4.0
+- citation: This course material was developed as part of UNIVERSE-HPC, which is funded through the SPF ExCALIBUR programme under grant number EP/W035731/1 
+  url: https://www.universe-hpc.ac.uk
+  image: https://www.universe-hpc.ac.uk/assets/images/universe-hpc.png
+  license: CC-BY-4.0
 
 ---
 

--- a/scientific_computing/essential_maths/09_differential_equations_1.md
+++ b/scientific_computing/essential_maths/09_differential_equations_1.md
@@ -6,13 +6,13 @@ dependsOn: [
 tags: []
 attribution: 
 - citation: This material has been adapted from material by Fergus Cooper from the "Essential Mathematics" module of the SABS R³ Center for Doctoral Training.
-    url: https://www.sabsr3.ox.ac.uk
-    image: https://www.sabsr3.ox.ac.uk/sites/default/files/styles/site_logo/public/styles/site_logo/public/sabsr3/site-logo/sabs_r3_cdt_logo_v3_111x109.png
-    license: CC-BY-4.0
-  - citation: This course material was developed as part of UNIVERSE-HPC, which is funded through the SPF ExCALIBUR programme under grant number EP/W035731/1 
-    url: https://www.universe-hpc.ac.uk
-    image: https://www.universe-hpc.ac.uk/assets/images/universe-hpc.png
-    license: CC-BY-4.0
+  url: https://www.sabsr3.ox.ac.uk
+  image: https://www.sabsr3.ox.ac.uk/sites/default/files/styles/site_logo/public/styles/site_logo/public/sabsr3/site-logo/sabs_r3_cdt_logo_v3_111x109.png
+  license: CC-BY-4.0
+- citation: This course material was developed as part of UNIVERSE-HPC, which is funded through the SPF ExCALIBUR programme under grant number EP/W035731/1 
+  url: https://www.universe-hpc.ac.uk
+  image: https://www.universe-hpc.ac.uk/assets/images/universe-hpc.png
+  license: CC-BY-4.0
 
 ---
 

--- a/scientific_computing/essential_maths/10_differential_equations_2.md
+++ b/scientific_computing/essential_maths/10_differential_equations_2.md
@@ -6,13 +6,13 @@ dependsOn: [
 tags: []
 attribution: 
 - citation: This material has been adapted from material by Fergus Cooper from the "Essential Mathematics" module of the SABS R³ Center for Doctoral Training.
-    url: https://www.sabsr3.ox.ac.uk
-    image: https://www.sabsr3.ox.ac.uk/sites/default/files/styles/site_logo/public/styles/site_logo/public/sabsr3/site-logo/sabs_r3_cdt_logo_v3_111x109.png
-    license: CC-BY-4.0
-  - citation: This course material was developed as part of UNIVERSE-HPC, which is funded through the SPF ExCALIBUR programme under grant number EP/W035731/1 
-    url: https://www.universe-hpc.ac.uk
-    image: https://www.universe-hpc.ac.uk/assets/images/universe-hpc.png
-    license: CC-BY-4.0
+  url: https://www.sabsr3.ox.ac.uk
+  image: https://www.sabsr3.ox.ac.uk/sites/default/files/styles/site_logo/public/styles/site_logo/public/sabsr3/site-logo/sabs_r3_cdt_logo_v3_111x109.png
+  license: CC-BY-4.0
+- citation: This course material was developed as part of UNIVERSE-HPC, which is funded through the SPF ExCALIBUR programme under grant number EP/W035731/1 
+  url: https://www.universe-hpc.ac.uk
+  image: https://www.universe-hpc.ac.uk/assets/images/universe-hpc.png
+  license: CC-BY-4.0
 
 ---
 

--- a/scientific_computing/essential_maths/11_differential_equations_3.md
+++ b/scientific_computing/essential_maths/11_differential_equations_3.md
@@ -6,13 +6,13 @@ dependsOn: [
 tags: []
 attribution: 
 - citation: This material has been adapted from material by Fergus Cooper from the "Essential Mathematics" module of the SABS R³ Center for Doctoral Training.
-    url: https://www.sabsr3.ox.ac.uk
-    image: https://www.sabsr3.ox.ac.uk/sites/default/files/styles/site_logo/public/styles/site_logo/public/sabsr3/site-logo/sabs_r3_cdt_logo_v3_111x109.png
-    license: CC-BY-4.0
-  - citation: This course material was developed as part of UNIVERSE-HPC, which is funded through the SPF ExCALIBUR programme under grant number EP/W035731/1 
-    url: https://www.universe-hpc.ac.uk
-    image: https://www.universe-hpc.ac.uk/assets/images/universe-hpc.png
-    license: CC-BY-4.0
+  url: https://www.sabsr3.ox.ac.uk
+  image: https://www.sabsr3.ox.ac.uk/sites/default/files/styles/site_logo/public/styles/site_logo/public/sabsr3/site-logo/sabs_r3_cdt_logo_v3_111x109.png
+  license: CC-BY-4.0
+- citation: This course material was developed as part of UNIVERSE-HPC, which is funded through the SPF ExCALIBUR programme under grant number EP/W035731/1 
+  url: https://www.universe-hpc.ac.uk
+  image: https://www.universe-hpc.ac.uk/assets/images/universe-hpc.png
+  license: CC-BY-4.0
 
 ---
 

--- a/scientific_computing/essential_maths/12_linear_algebra_1.md
+++ b/scientific_computing/essential_maths/12_linear_algebra_1.md
@@ -6,14 +6,13 @@ dependsOn: [
 tags: []
 attribution: 
 - citation: This material has been adapted from material by Fergus Cooper from the "Essential Mathematics" module of the SABS R³ Center for Doctoral Training.
-    url: https://www.sabsr3.ox.ac.uk
-    image: https://www.sabsr3.ox.ac.uk/sites/default/files/styles/site_logo/public/styles/site_logo/public/sabsr3/site-logo/sabs_r3_cdt_logo_v3_111x109.png
-    license: CC-BY-4.0
-  - citation: This course material was developed as part of UNIVERSE-HPC, which is funded through the SPF ExCALIBUR programme under grant number EP/W035731/1 
-    url: https://www.universe-hpc.ac.uk
-    image: https://www.universe-hpc.ac.uk/assets/images/universe-hpc.png
-    license: CC-BY-4.0
-
+  url: https://www.sabsr3.ox.ac.uk
+  image: https://www.sabsr3.ox.ac.uk/sites/default/files/styles/site_logo/public/styles/site_logo/public/sabsr3/site-logo/sabs_r3_cdt_logo_v3_111x109.png
+  license: CC-BY-4.0
+- citation: This course material was developed as part of UNIVERSE-HPC, which is funded through the SPF ExCALIBUR programme under grant number EP/W035731/1 
+  url: https://www.universe-hpc.ac.uk
+  image: https://www.universe-hpc.ac.uk/assets/images/universe-hpc.png
+  license: CC-BY-4.0
 ---
 
 ## Introduction to Matrices

--- a/scientific_computing/essential_maths/13_linear_algebra_2.md
+++ b/scientific_computing/essential_maths/13_linear_algebra_2.md
@@ -6,13 +6,13 @@ dependsOn: [
 tags: []
 attribution: 
 - citation: This material has been adapted from material by Fergus Cooper from the "Essential Mathematics" module of the SABS R³ Center for Doctoral Training.
-    url: https://www.sabsr3.ox.ac.uk
-    image: https://www.sabsr3.ox.ac.uk/sites/default/files/styles/site_logo/public/styles/site_logo/public/sabsr3/site-logo/sabs_r3_cdt_logo_v3_111x109.png
-    license: CC-BY-4.0
-  - citation: This course material was developed as part of UNIVERSE-HPC, which is funded through the SPF ExCALIBUR programme under grant number EP/W035731/1 
-    url: https://www.universe-hpc.ac.uk
-    image: https://www.universe-hpc.ac.uk/assets/images/universe-hpc.png
-    license: CC-BY-4.0
+  url: https://www.sabsr3.ox.ac.uk
+  image: https://www.sabsr3.ox.ac.uk/sites/default/files/styles/site_logo/public/styles/site_logo/public/sabsr3/site-logo/sabs_r3_cdt_logo_v3_111x109.png
+  license: CC-BY-4.0
+- citation: This course material was developed as part of UNIVERSE-HPC, which is funded through the SPF ExCALIBUR programme under grant number EP/W035731/1 
+  url: https://www.universe-hpc.ac.uk
+  image: https://www.universe-hpc.ac.uk/assets/images/universe-hpc.png
+  license: CC-BY-4.0
 
 ---
 

--- a/scientific_computing/essential_maths/14_system_1.md
+++ b/scientific_computing/essential_maths/14_system_1.md
@@ -7,13 +7,13 @@ dependsOn: [
 tags: []
 attribution: 
 - citation: This material has been adapted from material by Fergus Cooper from the "Essential Mathematics" module of the SABS R³ Center for Doctoral Training.
-    url: https://www.sabsr3.ox.ac.uk
-    image: https://www.sabsr3.ox.ac.uk/sites/default/files/styles/site_logo/public/styles/site_logo/public/sabsr3/site-logo/sabs_r3_cdt_logo_v3_111x109.png
-    license: CC-BY-4.0
-  - citation: This course material was developed as part of UNIVERSE-HPC, which is funded through the SPF ExCALIBUR programme under grant number EP/W035731/1 
-    url: https://www.universe-hpc.ac.uk
-    image: https://www.universe-hpc.ac.uk/assets/images/universe-hpc.png
-    license: CC-BY-4.0
+  url: https://www.sabsr3.ox.ac.uk
+  image: https://www.sabsr3.ox.ac.uk/sites/default/files/styles/site_logo/public/styles/site_logo/public/sabsr3/site-logo/sabs_r3_cdt_logo_v3_111x109.png
+  license: CC-BY-4.0
+- citation: This course material was developed as part of UNIVERSE-HPC, which is funded through the SPF ExCALIBUR programme under grant number EP/W035731/1 
+  url: https://www.universe-hpc.ac.uk
+  image: https://www.universe-hpc.ac.uk/assets/images/universe-hpc.png
+  license: CC-BY-4.0
 
 ---
 

--- a/scientific_computing/essential_maths/15_system_2.md
+++ b/scientific_computing/essential_maths/15_system_2.md
@@ -6,14 +6,13 @@ dependsOn: [
 tags: []
 attribution: 
 - citation: This material has been adapted from material by Fergus Cooper from the "Essential Mathematics" module of the SABS R³ Center for Doctoral Training.
-    url: https://www.sabsr3.ox.ac.uk
-    image: https://www.sabsr3.ox.ac.uk/sites/default/files/styles/site_logo/public/styles/site_logo/public/sabsr3/site-logo/sabs_r3_cdt_logo_v3_111x109.png
-    license: CC-BY-4.0
-  - citation: This course material was developed as part of UNIVERSE-HPC, which is funded through the SPF ExCALIBUR programme under grant number EP/W035731/1 
-    url: https://www.universe-hpc.ac.uk
-    image: https://www.universe-hpc.ac.uk/assets/images/universe-hpc.png
-    license: CC-BY-4.0
-
+  url: https://www.sabsr3.ox.ac.uk
+  image: https://www.sabsr3.ox.ac.uk/sites/default/files/styles/site_logo/public/styles/site_logo/public/sabsr3/site-logo/sabs_r3_cdt_logo_v3_111x109.png
+  license: CC-BY-4.0
+- citation: This course material was developed as part of UNIVERSE-HPC, which is funded through the SPF ExCALIBUR programme under grant number EP/W035731/1 
+  url: https://www.universe-hpc.ac.uk
+  image: https://www.universe-hpc.ac.uk/assets/images/universe-hpc.png
+  license: CC-BY-4.0
 ---
 
 ## System Simplification

--- a/scientific_computing/essential_maths/16_system_3.md
+++ b/scientific_computing/essential_maths/16_system_3.md
@@ -6,13 +6,13 @@ dependsOn: [
 tags: []
 attribution: 
 - citation: This material has been adapted from material by Fergus Cooper from the "Essential Mathematics" module of the SABS R³ Center for Doctoral Training.
-    url: https://www.sabsr3.ox.ac.uk
-    image: https://www.sabsr3.ox.ac.uk/sites/default/files/styles/site_logo/public/styles/site_logo/public/sabsr3/site-logo/sabs_r3_cdt_logo_v3_111x109.png
-    license: CC-BY-4.0
-  - citation: This course material was developed as part of UNIVERSE-HPC, which is funded through the SPF ExCALIBUR programme under grant number EP/W035731/1 
-    url: https://www.universe-hpc.ac.uk
-    image: https://www.universe-hpc.ac.uk/assets/images/universe-hpc.png
-    license: CC-BY-4.0
+  url: https://www.sabsr3.ox.ac.uk
+  image: https://www.sabsr3.ox.ac.uk/sites/default/files/styles/site_logo/public/styles/site_logo/public/sabsr3/site-logo/sabs_r3_cdt_logo_v3_111x109.png
+  license: CC-BY-4.0
+- citation: This course material was developed as part of UNIVERSE-HPC, which is funded through the SPF ExCALIBUR programme under grant number EP/W035731/1 
+  url: https://www.universe-hpc.ac.uk
+  image: https://www.universe-hpc.ac.uk/assets/images/universe-hpc.png
+  license: CC-BY-4.0
 
 ---
 

--- a/scientific_computing/essential_maths/17_probability_1.md
+++ b/scientific_computing/essential_maths/17_probability_1.md
@@ -6,13 +6,13 @@ dependsOn: [
 tags: []
 attribution: 
 - citation: This material has been adapted from material by Fergus Cooper from the "Essential Mathematics" module of the SABS R³ Center for Doctoral Training.
-    url: https://www.sabsr3.ox.ac.uk
-    image: https://www.sabsr3.ox.ac.uk/sites/default/files/styles/site_logo/public/styles/site_logo/public/sabsr3/site-logo/sabs_r3_cdt_logo_v3_111x109.png
-    license: CC-BY-4.0
-  - citation: This course material was developed as part of UNIVERSE-HPC, which is funded through the SPF ExCALIBUR programme under grant number EP/W035731/1 
-    url: https://www.universe-hpc.ac.uk
-    image: https://www.universe-hpc.ac.uk/assets/images/universe-hpc.png
-    license: CC-BY-4.0
+  url: https://www.sabsr3.ox.ac.uk
+  image: https://www.sabsr3.ox.ac.uk/sites/default/files/styles/site_logo/public/styles/site_logo/public/sabsr3/site-logo/sabs_r3_cdt_logo_v3_111x109.png
+  license: CC-BY-4.0
+- citation: This course material was developed as part of UNIVERSE-HPC, which is funded through the SPF ExCALIBUR programme under grant number EP/W035731/1 
+  url: https://www.universe-hpc.ac.uk
+  image: https://www.universe-hpc.ac.uk/assets/images/universe-hpc.png
+  license: CC-BY-4.0
 
 ---
 

--- a/scientific_computing/essential_maths/18_probability_2.md
+++ b/scientific_computing/essential_maths/18_probability_2.md
@@ -6,13 +6,13 @@ dependsOn: [
 tags: []
 attribution: 
 - citation: This material has been adapted from material by Fergus Cooper from the "Essential Mathematics" module of the SABS R³ Center for Doctoral Training.
-    url: https://www.sabsr3.ox.ac.uk
-    image: https://www.sabsr3.ox.ac.uk/sites/default/files/styles/site_logo/public/styles/site_logo/public/sabsr3/site-logo/sabs_r3_cdt_logo_v3_111x109.png
-    license: CC-BY-4.0
-  - citation: This course material was developed as part of UNIVERSE-HPC, which is funded through the SPF ExCALIBUR programme under grant number EP/W035731/1 
-    url: https://www.universe-hpc.ac.uk
-    image: https://www.universe-hpc.ac.uk/assets/images/universe-hpc.png
-    license: CC-BY-4.0
+  url: https://www.sabsr3.ox.ac.uk
+  image: https://www.sabsr3.ox.ac.uk/sites/default/files/styles/site_logo/public/styles/site_logo/public/sabsr3/site-logo/sabs_r3_cdt_logo_v3_111x109.png
+  license: CC-BY-4.0
+- citation: This course material was developed as part of UNIVERSE-HPC, which is funded through the SPF ExCALIBUR programme under grant number EP/W035731/1 
+  url: https://www.universe-hpc.ac.uk
+  image: https://www.universe-hpc.ac.uk/assets/images/universe-hpc.png
+  license: CC-BY-4.0
 
 ---
 

--- a/scientific_computing/essential_maths/19_probability_3.md
+++ b/scientific_computing/essential_maths/19_probability_3.md
@@ -6,14 +6,13 @@ dependsOn: [
 tags: []
 attribution: 
 - citation: This material has been adapted from material by Fergus Cooper from the "Essential Mathematics" module of the SABS R³ Center for Doctoral Training.
-    url: https://www.sabsr3.ox.ac.uk
-    image: https://www.sabsr3.ox.ac.uk/sites/default/files/styles/site_logo/public/styles/site_logo/public/sabsr3/site-logo/sabs_r3_cdt_logo_v3_111x109.png
-    license: CC-BY-4.0
-  - citation: This course material was developed as part of UNIVERSE-HPC, which is funded through the SPF ExCALIBUR programme under grant number EP/W035731/1 
-    url: https://www.universe-hpc.ac.uk
-    image: https://www.universe-hpc.ac.uk/assets/images/universe-hpc.png
-    license: CC-BY-4.0
-
+  url: https://www.sabsr3.ox.ac.uk
+  image: https://www.sabsr3.ox.ac.uk/sites/default/files/styles/site_logo/public/styles/site_logo/public/sabsr3/site-logo/sabs_r3_cdt_logo_v3_111x109.png
+  license: CC-BY-4.0
+- citation: This course material was developed as part of UNIVERSE-HPC, which is funded through the SPF ExCALIBUR programme under grant number EP/W035731/1 
+  url: https://www.universe-hpc.ac.uk
+  image: https://www.universe-hpc.ac.uk/assets/images/universe-hpc.png
+  license: CC-BY-4.0
 ---
 
 Coming soon.

--- a/scientific_computing/essential_maths/index.md
+++ b/scientific_computing/essential_maths/index.md
@@ -27,14 +27,13 @@ summary: |
     A course in maths, containing a primer in everything you need to know in order to analyse systems of differential equations. 
 attribution: 
 - citation: This material has been adapted from material by Fergus Cooper from the "Essential Mathematics" module of the SABS R³ Center for Doctoral Training.
-    url: https://www.sabsr3.ox.ac.uk
-    image: https://www.sabsr3.ox.ac.uk/sites/default/files/styles/site_logo/public/styles/site_logo/public/sabsr3/site-logo/sabs_r3_cdt_logo_v3_111x109.png
-    license: CC-BY-4.0
-  - citation: This course material was developed as part of UNIVERSE-HPC, which is funded through the SPF ExCALIBUR programme under grant number EP/W035731/1 
-    url: https://www.universe-hpc.ac.uk
-    image: https://www.universe-hpc.ac.uk/assets/images/universe-hpc.png
-    license: CC-BY-4.0
-
+  url: https://www.sabsr3.ox.ac.uk
+  image: https://www.sabsr3.ox.ac.uk/sites/default/files/styles/site_logo/public/styles/site_logo/public/sabsr3/site-logo/sabs_r3_cdt_logo_v3_111x109.png
+  license: CC-BY-4.0
+- citation: This course material was developed as part of UNIVERSE-HPC, which is funded through the SPF ExCALIBUR programme under grant number EP/W035731/1 
+  url: https://www.universe-hpc.ac.uk
+  image: https://www.universe-hpc.ac.uk/assets/images/universe-hpc.png
+  license: CC-BY-4.0
 ---
 
 The most recent substantial iteration of this course was developed by Fergus Cooper, Beth Dingley, and Elliot Howard-Spink.

--- a/scientific_computing/linear_algebra/01-matrix-form-of-equations.md
+++ b/scientific_computing/linear_algebra/01-matrix-form-of-equations.md
@@ -5,13 +5,13 @@ dependsOn: [
 tags: []
 attribution: 
 - citation: This material has been adapted from material by Martin Robinson from the "Scientific Computing" module of the SABS R³ Center for Doctoral Training.
-    url: https://www.sabsr3.ox.ac.uk
-    image: https://www.sabsr3.ox.ac.uk/sites/default/files/styles/site_logo/public/styles/site_logo/public/sabsr3/site-logo/sabs_r3_cdt_logo_v3_111x109.png
-    license: CC-BY-4.0
-  - citation: This course material was developed as part of UNIVERSE-HPC, which is funded through the SPF ExCALIBUR programme under grant number EP/W035731/1 
-    url: https://www.universe-hpc.ac.uk
-    image: https://www.universe-hpc.ac.uk/assets/images/universe-hpc.png
-    license: CC-BY-4.0
+  url: https://www.sabsr3.ox.ac.uk
+  image: https://www.sabsr3.ox.ac.uk/sites/default/files/styles/site_logo/public/styles/site_logo/public/sabsr3/site-logo/sabs_r3_cdt_logo_v3_111x109.png
+  license: CC-BY-4.0
+- citation: This course material was developed as part of UNIVERSE-HPC, which is funded through the SPF ExCALIBUR programme under grant number EP/W035731/1 
+  url: https://www.universe-hpc.ac.uk
+  image: https://www.universe-hpc.ac.uk/assets/images/universe-hpc.png
+  license: CC-BY-4.0
 
 
 ---

--- a/scientific_computing/linear_algebra/02-gaussian-elimination.md
+++ b/scientific_computing/linear_algebra/02-gaussian-elimination.md
@@ -14,13 +14,13 @@ learningOutcomes:
 - "Understand and be able to implement Gaussian Elimination"
 attribution: 
 - citation: This material has been adapted from material by Martin Robinson from the "Scientific Computing" module of the SABS R³ Center for Doctoral Training.
-    url: https://www.sabsr3.ox.ac.uk
-    image: https://www.sabsr3.ox.ac.uk/sites/default/files/styles/site_logo/public/styles/site_logo/public/sabsr3/site-logo/sabs_r3_cdt_logo_v3_111x109.png
-    license: CC-BY-4.0
-  - citation: This course material was developed as part of UNIVERSE-HPC, which is funded through the SPF ExCALIBUR programme under grant number EP/W035731/1 
-    url: https://www.universe-hpc.ac.uk
-    image: https://www.universe-hpc.ac.uk/assets/images/universe-hpc.png
-    license: CC-BY-4.0
+  url: https://www.sabsr3.ox.ac.uk
+  image: https://www.sabsr3.ox.ac.uk/sites/default/files/styles/site_logo/public/styles/site_logo/public/sabsr3/site-logo/sabs_r3_cdt_logo_v3_111x109.png
+  license: CC-BY-4.0
+- citation: This course material was developed as part of UNIVERSE-HPC, which is funded through the SPF ExCALIBUR programme under grant number EP/W035731/1 
+  url: https://www.universe-hpc.ac.uk
+  image: https://www.universe-hpc.ac.uk/assets/images/universe-hpc.png
+  license: CC-BY-4.0
 ---
 
 ## Gaussian Elimination

--- a/scientific_computing/linear_algebra/04-LU-decomposition.md
+++ b/scientific_computing/linear_algebra/04-LU-decomposition.md
@@ -6,13 +6,13 @@ dependsOn: [
 tags: []
 attribution: 
 - citation: This material has been adapted from material by Martin Robinson from the "Scientific Computing" module of the SABS R³ Center for Doctoral Training.
-    url: https://www.sabsr3.ox.ac.uk
-    image: https://www.sabsr3.ox.ac.uk/sites/default/files/styles/site_logo/public/styles/site_logo/public/sabsr3/site-logo/sabs_r3_cdt_logo_v3_111x109.png
-    license: CC-BY-4.0
-  - citation: This course material was developed as part of UNIVERSE-HPC, which is funded through the SPF ExCALIBUR programme under grant number EP/W035731/1 
-    url: https://www.universe-hpc.ac.uk
-    image: https://www.universe-hpc.ac.uk/assets/images/universe-hpc.png
-    license: CC-BY-4.0
+  url: https://www.sabsr3.ox.ac.uk
+  image: https://www.sabsr3.ox.ac.uk/sites/default/files/styles/site_logo/public/styles/site_logo/public/sabsr3/site-logo/sabs_r3_cdt_logo_v3_111x109.png
+  license: CC-BY-4.0
+- citation: This course material was developed as part of UNIVERSE-HPC, which is funded through the SPF ExCALIBUR programme under grant number EP/W035731/1 
+  url: https://www.universe-hpc.ac.uk
+  image: https://www.universe-hpc.ac.uk/assets/images/universe-hpc.png
+  license: CC-BY-4.0
 ---
 
 ---

--- a/scientific_computing/linear_algebra/06-Cholesky-decomposition.md
+++ b/scientific_computing/linear_algebra/06-Cholesky-decomposition.md
@@ -6,13 +6,13 @@ dependsOn: [
 tags: []
 attribution: 
 - citation: This material has been adapted from material by Martin Robinson from the "Scientific Computing" module of the SABS R³ Center for Doctoral Training.
-    url: https://www.sabsr3.ox.ac.uk
-    image: https://www.sabsr3.ox.ac.uk/sites/default/files/styles/site_logo/public/styles/site_logo/public/sabsr3/site-logo/sabs_r3_cdt_logo_v3_111x109.png
-    license: CC-BY-4.0
-  - citation: This course material was developed as part of UNIVERSE-HPC, which is funded through the SPF ExCALIBUR programme under grant number EP/W035731/1 
-    url: https://www.universe-hpc.ac.uk
-    image: https://www.universe-hpc.ac.uk/assets/images/universe-hpc.png
-    license: CC-BY-4.0
+  url: https://www.sabsr3.ox.ac.uk
+  image: https://www.sabsr3.ox.ac.uk/sites/default/files/styles/site_logo/public/styles/site_logo/public/sabsr3/site-logo/sabs_r3_cdt_logo_v3_111x109.png
+  license: CC-BY-4.0
+- citation: This course material was developed as part of UNIVERSE-HPC, which is funded through the SPF ExCALIBUR programme under grant number EP/W035731/1 
+  url: https://www.universe-hpc.ac.uk
+  image: https://www.universe-hpc.ac.uk/assets/images/universe-hpc.png
+  license: CC-BY-4.0
 
 ---
 

--- a/scientific_computing/linear_algebra/07-QR-decomposition.md
+++ b/scientific_computing/linear_algebra/07-QR-decomposition.md
@@ -6,13 +6,13 @@ dependsOn: [
 tags: []
 attribution: 
 - citation: This material has been adapted from material by Martin Robinson from the "Scientific Computing" module of the SABS R³ Center for Doctoral Training.
-    url: https://www.sabsr3.ox.ac.uk
-    image: https://www.sabsr3.ox.ac.uk/sites/default/files/styles/site_logo/public/styles/site_logo/public/sabsr3/site-logo/sabs_r3_cdt_logo_v3_111x109.png
-    license: CC-BY-4.0
-  - citation: This course material was developed as part of UNIVERSE-HPC, which is funded through the SPF ExCALIBUR programme under grant number EP/W035731/1 
-    url: https://www.universe-hpc.ac.uk
-    image: https://www.universe-hpc.ac.uk/assets/images/universe-hpc.png
-    license: CC-BY-4.0
+  url: https://www.sabsr3.ox.ac.uk
+  image: https://www.sabsr3.ox.ac.uk/sites/default/files/styles/site_logo/public/styles/site_logo/public/sabsr3/site-logo/sabs_r3_cdt_logo_v3_111x109.png
+  license: CC-BY-4.0
+- citation: This course material was developed as part of UNIVERSE-HPC, which is funded through the SPF ExCALIBUR programme under grant number EP/W035731/1 
+  url: https://www.universe-hpc.ac.uk
+  image: https://www.universe-hpc.ac.uk/assets/images/universe-hpc.png
+  license: CC-BY-4.0
 
 ---
 

--- a/scientific_computing/linear_algebra/index.md
+++ b/scientific_computing/linear_algebra/index.md
@@ -18,13 +18,13 @@ summary: |
   covered, as well as some standard Python libraries for linear algebra.
 attribution: 
 - citation: This material has been adapted from material by Martin Robinson from the "Scientific Computing" module of the SABS R³ Center for Doctoral Training.
-    url: https://www.sabsr3.ox.ac.uk
-    image: https://www.sabsr3.ox.ac.uk/sites/default/files/styles/site_logo/public/styles/site_logo/public/sabsr3/site-logo/sabs_r3_cdt_logo_v3_111x109.png
-    license: CC-BY-4.0
-  - citation: This course material was developed as part of UNIVERSE-HPC, which is funded through the SPF ExCALIBUR programme under grant number EP/W035731/1 
-    url: https://www.universe-hpc.ac.uk
-    image: https://www.universe-hpc.ac.uk/assets/images/universe-hpc.png
-    license: CC-BY-4.0
+  url: https://www.sabsr3.ox.ac.uk
+  image: https://www.sabsr3.ox.ac.uk/sites/default/files/styles/site_logo/public/styles/site_logo/public/sabsr3/site-logo/sabs_r3_cdt_logo_v3_111x109.png
+  license: CC-BY-4.0
+- citation: This course material was developed as part of UNIVERSE-HPC, which is funded through the SPF ExCALIBUR programme under grant number EP/W035731/1 
+  url: https://www.universe-hpc.ac.uk
+  image: https://www.universe-hpc.ac.uk/assets/images/universe-hpc.png
+  license: CC-BY-4.0
 
 
 ---

--- a/scientific_computing/ode_solvers/01-AM.md
+++ b/scientific_computing/ode_solvers/01-AM.md
@@ -5,13 +5,13 @@ dependsOn: [
 tags: []
 attribution: 
 - citation: This material has been adapted from material by Joe Pitt-Francis from the "Scientific Computing" module of the SABS R³ Center for Doctoral Training.
-    url: https://www.sabsr3.ox.ac.uk
-    image: https://www.sabsr3.ox.ac.uk/sites/default/files/styles/site_logo/public/styles/site_logo/public/sabsr3/site-logo/sabs_r3_cdt_logo_v3_111x109.png
-    license: CC-BY-4.0
-  - citation: This course material was developed as part of UNIVERSE-HPC, which is funded through the SPF ExCALIBUR programme under grant number EP/W035731/1 
-    url: https://www.universe-hpc.ac.uk
-    image: https://www.universe-hpc.ac.uk/assets/images/universe-hpc.png
-    license: CC-BY-4.0
+  url: https://www.sabsr3.ox.ac.uk
+  image: https://www.sabsr3.ox.ac.uk/sites/default/files/styles/site_logo/public/styles/site_logo/public/sabsr3/site-logo/sabs_r3_cdt_logo_v3_111x109.png
+  license: CC-BY-4.0
+- citation: This course material was developed as part of UNIVERSE-HPC, which is funded through the SPF ExCALIBUR programme under grant number EP/W035731/1 
+  url: https://www.universe-hpc.ac.uk
+  image: https://www.universe-hpc.ac.uk/assets/images/universe-hpc.png
+  license: CC-BY-4.0
 
 
 ---

--- a/scientific_computing/ode_solvers/02-PM.md
+++ b/scientific_computing/ode_solvers/02-PM.md
@@ -6,13 +6,13 @@ dependsOn: [
 tags: []
 attribution: 
 - citation: This material has been adapted from material by Joe Pitt-Francis from the "Scientific Computing" module of the SABS R³ Center for Doctoral Training.
-    url: https://www.sabsr3.ox.ac.uk
-    image: https://www.sabsr3.ox.ac.uk/sites/default/files/styles/site_logo/public/styles/site_logo/public/sabsr3/site-logo/sabs_r3_cdt_logo_v3_111x109.png
-    license: CC-BY-4.0
-  - citation: This course material was developed as part of UNIVERSE-HPC, which is funded through the SPF ExCALIBUR programme under grant number EP/W035731/1 
-    url: https://www.universe-hpc.ac.uk
-    image: https://www.universe-hpc.ac.uk/assets/images/universe-hpc.png
-    license: CC-BY-4.0
+  url: https://www.sabsr3.ox.ac.uk
+  image: https://www.sabsr3.ox.ac.uk/sites/default/files/styles/site_logo/public/styles/site_logo/public/sabsr3/site-logo/sabs_r3_cdt_logo_v3_111x109.png
+  license: CC-BY-4.0
+- citation: This course material was developed as part of UNIVERSE-HPC, which is funded through the SPF ExCALIBUR programme under grant number EP/W035731/1 
+  url: https://www.universe-hpc.ac.uk
+  image: https://www.universe-hpc.ac.uk/assets/images/universe-hpc.png
+  license: CC-BY-4.0
 
 
 ---

--- a/scientific_computing/ode_solvers/index.md
+++ b/scientific_computing/ode_solvers/index.md
@@ -10,13 +10,13 @@ files: [
 ]
 attribution: 
 - citation: This material has been adapted from material by Joe Pitt-Francis from the "Scientific Computing" module of the SABS R³ Center for Doctoral Training.
-    url: https://www.sabsr3.ox.ac.uk
-    image: https://www.sabsr3.ox.ac.uk/sites/default/files/styles/site_logo/public/styles/site_logo/public/sabsr3/site-logo/sabs_r3_cdt_logo_v3_111x109.png
-    license: CC-BY-4.0
-  - citation: This course material was developed as part of UNIVERSE-HPC, which is funded through the SPF ExCALIBUR programme under grant number EP/W035731/1 
-    url: https://www.universe-hpc.ac.uk
-    image: https://www.universe-hpc.ac.uk/assets/images/universe-hpc.png
-    license: CC-BY-4.0
+  url: https://www.sabsr3.ox.ac.uk
+  image: https://www.sabsr3.ox.ac.uk/sites/default/files/styles/site_logo/public/styles/site_logo/public/sabsr3/site-logo/sabs_r3_cdt_logo_v3_111x109.png
+  license: CC-BY-4.0
+- citation: This course material was developed as part of UNIVERSE-HPC, which is funded through the SPF ExCALIBUR programme under grant number EP/W035731/1 
+  url: https://www.universe-hpc.ac.uk
+  image: https://www.universe-hpc.ac.uk/assets/images/universe-hpc.png
+  license: CC-BY-4.0
 
 
 ---

--- a/scientific_computing/optimisation/01-nonlinear-optimisation.md
+++ b/scientific_computing/optimisation/01-nonlinear-optimisation.md
@@ -5,14 +5,13 @@ dependsOn: [
 tags: []
 attribution: 
 - citation: This material has been adapted from material by Martin Robinson from the "Scientific Computing" module of the SABS R³ Center for Doctoral Training.
-    url: https://www.sabsr3.ox.ac.uk
-    image: https://www.sabsr3.ox.ac.uk/sites/default/files/styles/site_logo/public/styles/site_logo/public/sabsr3/site-logo/sabs_r3_cdt_logo_v3_111x109.png
-    license: CC-BY-4.0
-  - citation: This course material was developed as part of UNIVERSE-HPC, which is funded through the SPF ExCALIBUR programme under grant number EP/W035731/1 
-    url: https://www.universe-hpc.ac.uk
-    image: https://www.universe-hpc.ac.uk/assets/images/universe-hpc.png
-    license: CC-BY-4.0
-
+  url: https://www.sabsr3.ox.ac.uk
+  image: https://www.sabsr3.ox.ac.uk/sites/default/files/styles/site_logo/public/styles/site_logo/public/sabsr3/site-logo/sabs_r3_cdt_logo_v3_111x109.png
+  license: CC-BY-4.0
+- citation: This course material was developed as part of UNIVERSE-HPC, which is funded through the SPF ExCALIBUR programme under grant number EP/W035731/1 
+  url: https://www.universe-hpc.ac.uk
+  image: https://www.universe-hpc.ac.uk/assets/images/universe-hpc.png
+  license: CC-BY-4.0
 
 ---
 

--- a/scientific_computing/optimisation/02-line-search-methods.md
+++ b/scientific_computing/optimisation/02-line-search-methods.md
@@ -6,14 +6,13 @@ dependsOn: [
 tags: []
 attribution: 
 - citation: This material has been adapted from material by Martin Robinson from the "Scientific Computing" module of the SABS R³ Center for Doctoral Training.
-    url: https://www.sabsr3.ox.ac.uk
-    image: https://www.sabsr3.ox.ac.uk/sites/default/files/styles/site_logo/public/styles/site_logo/public/sabsr3/site-logo/sabs_r3_cdt_logo_v3_111x109.png
-    license: CC-BY-4.0
-  - citation: This course material was developed as part of UNIVERSE-HPC, which is funded through the SPF ExCALIBUR programme under grant number EP/W035731/1 
-    url: https://www.universe-hpc.ac.uk
-    image: https://www.universe-hpc.ac.uk/assets/images/universe-hpc.png
-    license: CC-BY-4.0
-
+  url: https://www.sabsr3.ox.ac.uk
+  image: https://www.sabsr3.ox.ac.uk/sites/default/files/styles/site_logo/public/styles/site_logo/public/sabsr3/site-logo/sabs_r3_cdt_logo_v3_111x109.png
+  license: CC-BY-4.0
+- citation: This course material was developed as part of UNIVERSE-HPC, which is funded through the SPF ExCALIBUR programme under grant number EP/W035731/1 
+  url: https://www.universe-hpc.ac.uk
+  image: https://www.universe-hpc.ac.uk/assets/images/universe-hpc.png
+  license: CC-BY-4.0
 
 ---
 

--- a/scientific_computing/optimisation/03-trust-region-methods.md
+++ b/scientific_computing/optimisation/03-trust-region-methods.md
@@ -6,14 +6,13 @@ dependsOn: [
 tags: []
 attribution: 
 - citation: This material has been adapted from material by Martin Robinson from the "Scientific Computing" module of the SABS R³ Center for Doctoral Training.
-    url: https://www.sabsr3.ox.ac.uk
-    image: https://www.sabsr3.ox.ac.uk/sites/default/files/styles/site_logo/public/styles/site_logo/public/sabsr3/site-logo/sabs_r3_cdt_logo_v3_111x109.png
-    license: CC-BY-4.0
-  - citation: This course material was developed as part of UNIVERSE-HPC, which is funded through the SPF ExCALIBUR programme under grant number EP/W035731/1 
-    url: https://www.universe-hpc.ac.uk
-    image: https://www.universe-hpc.ac.uk/assets/images/universe-hpc.png
-    license: CC-BY-4.0
-
+  url: https://www.sabsr3.ox.ac.uk
+  image: https://www.sabsr3.ox.ac.uk/sites/default/files/styles/site_logo/public/styles/site_logo/public/sabsr3/site-logo/sabs_r3_cdt_logo_v3_111x109.png
+  license: CC-BY-4.0
+- citation: This course material was developed as part of UNIVERSE-HPC, which is funded through the SPF ExCALIBUR programme under grant number EP/W035731/1 
+  url: https://www.universe-hpc.ac.uk
+  image: https://www.universe-hpc.ac.uk/assets/images/universe-hpc.png
+  license: CC-BY-4.0
 
 ---
 

--- a/scientific_computing/optimisation/05-finite-difference-method.md
+++ b/scientific_computing/optimisation/05-finite-difference-method.md
@@ -6,14 +6,13 @@ dependsOn: [
 tags: []
 attribution: 
 - citation: This material has been adapted from material by Martin Robinson from the "Scientific Computing" module of the SABS R³ Center for Doctoral Training.
-    url: https://www.sabsr3.ox.ac.uk
-    image: https://www.sabsr3.ox.ac.uk/sites/default/files/styles/site_logo/public/styles/site_logo/public/sabsr3/site-logo/sabs_r3_cdt_logo_v3_111x109.png
-    license: CC-BY-4.0
-  - citation: This course material was developed as part of UNIVERSE-HPC, which is funded through the SPF ExCALIBUR programme under grant number EP/W035731/1 
-    url: https://www.universe-hpc.ac.uk
-    image: https://www.universe-hpc.ac.uk/assets/images/universe-hpc.png
-    license: CC-BY-4.0
-
+  url: https://www.sabsr3.ox.ac.uk
+  image: https://www.sabsr3.ox.ac.uk/sites/default/files/styles/site_logo/public/styles/site_logo/public/sabsr3/site-logo/sabs_r3_cdt_logo_v3_111x109.png
+  license: CC-BY-4.0
+- citation: This course material was developed as part of UNIVERSE-HPC, which is funded through the SPF ExCALIBUR programme under grant number EP/W035731/1 
+  url: https://www.universe-hpc.ac.uk
+  image: https://www.universe-hpc.ac.uk/assets/images/universe-hpc.png
+  license: CC-BY-4.0
 
 ---
 

--- a/scientific_computing/optimisation/06-nelder-mead.md
+++ b/scientific_computing/optimisation/06-nelder-mead.md
@@ -6,14 +6,13 @@ dependsOn: [
 tags: []
 attribution: 
 - citation: This material has been adapted from material by Martin Robinson from the "Scientific Computing" module of the SABS R³ Center for Doctoral Training.
-    url: https://www.sabsr3.ox.ac.uk
-    image: https://www.sabsr3.ox.ac.uk/sites/default/files/styles/site_logo/public/styles/site_logo/public/sabsr3/site-logo/sabs_r3_cdt_logo_v3_111x109.png
-    license: CC-BY-4.0
-  - citation: This course material was developed as part of UNIVERSE-HPC, which is funded through the SPF ExCALIBUR programme under grant number EP/W035731/1 
-    url: https://www.universe-hpc.ac.uk
-    image: https://www.universe-hpc.ac.uk/assets/images/universe-hpc.png
-    license: CC-BY-4.0
-
+  url: https://www.sabsr3.ox.ac.uk
+  image: https://www.sabsr3.ox.ac.uk/sites/default/files/styles/site_logo/public/styles/site_logo/public/sabsr3/site-logo/sabs_r3_cdt_logo_v3_111x109.png
+  license: CC-BY-4.0
+- citation: This course material was developed as part of UNIVERSE-HPC, which is funded through the SPF ExCALIBUR programme under grant number EP/W035731/1 
+  url: https://www.universe-hpc.ac.uk
+  image: https://www.universe-hpc.ac.uk/assets/images/universe-hpc.png
+  license: CC-BY-4.0
 
 ---
 

--- a/scientific_computing/optimisation/index.md
+++ b/scientific_computing/optimisation/index.md
@@ -15,13 +15,14 @@ summary: |
     This course introduces the concept of continuous integration and how to set it up for a Python project using GitHub Actions.
 attribution: 
 - citation: This material has been adapted from material by Martin Robinson from the "Scientific Computing" module of the SABS R³ Center for Doctoral Training.
-    url: https://www.sabsr3.ox.ac.uk
-    image: https://www.sabsr3.ox.ac.uk/sites/default/files/styles/site_logo/public/styles/site_logo/public/sabsr3/site-logo/sabs_r3_cdt_logo_v3_111x109.png
-    license: CC-BY-4.0
-  - citation: This course material was developed as part of UNIVERSE-HPC, which is funded through the SPF ExCALIBUR programme under grant number EP/W035731/1 
-    url: https://www.universe-hpc.ac.uk
-    image: https://www.universe-hpc.ac.uk/assets/images/universe-hpc.png
-    license: CC-BY-4.0
+  url: https://www.sabsr3.ox.ac.uk
+  image: https://www.sabsr3.ox.ac.uk/sites/default/files/styles/site_logo/public/styles/site_logo/public/sabsr3/site-logo/sabs_r3_cdt_logo_v3_111x109.png
+  license: CC-BY-4.0
+- citation: This course material was developed as part of UNIVERSE-HPC, which is funded through the SPF ExCALIBUR programme under grant number EP/W035731/1 
+  url: https://www.universe-hpc.ac.uk
+  image: https://www.universe-hpc.ac.uk/assets/images/universe-hpc.png
+  license: CC-BY-4.0
+
 ---
 
 

--- a/scientific_computing/sparse_linear_algebra/01-sparse-matrices.md
+++ b/scientific_computing/sparse_linear_algebra/01-sparse-matrices.md
@@ -5,14 +5,13 @@ dependsOn: [
 tags: []
 attribution: 
 - citation: This material has been adapted from material by Martin Robinson from the "Scientific Computing" module of the SABS R³ Center for Doctoral Training.
-    url: https://www.sabsr3.ox.ac.uk
-    image: https://www.sabsr3.ox.ac.uk/sites/default/files/styles/site_logo/public/styles/site_logo/public/sabsr3/site-logo/sabs_r3_cdt_logo_v3_111x109.png
-    license: CC-BY-4.0
-  - citation: This course material was developed as part of UNIVERSE-HPC, which is funded through the SPF ExCALIBUR programme under grant number EP/W035731/1 
-    url: https://www.universe-hpc.ac.uk
-    image: https://www.universe-hpc.ac.uk/assets/images/universe-hpc.png
-    license: CC-BY-4.0
-
+  url: https://www.sabsr3.ox.ac.uk
+  image: https://www.sabsr3.ox.ac.uk/sites/default/files/styles/site_logo/public/styles/site_logo/public/sabsr3/site-logo/sabs_r3_cdt_logo_v3_111x109.png
+  license: CC-BY-4.0
+- citation: This course material was developed as part of UNIVERSE-HPC, which is funded through the SPF ExCALIBUR programme under grant number EP/W035731/1 
+  url: https://www.universe-hpc.ac.uk
+  image: https://www.universe-hpc.ac.uk/assets/images/universe-hpc.png
+  license: CC-BY-4.0
 ---
 
 ## Why sparse matrices

--- a/scientific_computing/sparse_linear_algebra/02-coo-matrix.md
+++ b/scientific_computing/sparse_linear_algebra/02-coo-matrix.md
@@ -6,13 +6,13 @@ dependsOn: [
 tags: []
 attribution: 
 - citation: This material has been adapted from material by Martin Robinson from the "Scientific Computing" module of the SABS R³ Center for Doctoral Training.
-    url: https://www.sabsr3.ox.ac.uk
-    image: https://www.sabsr3.ox.ac.uk/sites/default/files/styles/site_logo/public/styles/site_logo/public/sabsr3/site-logo/sabs_r3_cdt_logo_v3_111x109.png
-    license: CC-BY-4.0
-  - citation: This course material was developed as part of UNIVERSE-HPC, which is funded through the SPF ExCALIBUR programme under grant number EP/W035731/1 
-    url: https://www.universe-hpc.ac.uk
-    image: https://www.universe-hpc.ac.uk/assets/images/universe-hpc.png
-    license: CC-BY-4.0
+  url: https://www.sabsr3.ox.ac.uk
+  image: https://www.sabsr3.ox.ac.uk/sites/default/files/styles/site_logo/public/styles/site_logo/public/sabsr3/site-logo/sabs_r3_cdt_logo_v3_111x109.png
+  license: CC-BY-4.0
+- citation: This course material was developed as part of UNIVERSE-HPC, which is funded through the SPF ExCALIBUR programme under grant number EP/W035731/1 
+  url: https://www.universe-hpc.ac.uk
+  image: https://www.universe-hpc.ac.uk/assets/images/universe-hpc.png
+  license: CC-BY-4.0
 
 
 ---

--- a/scientific_computing/sparse_linear_algebra/03-finite-difference.md
+++ b/scientific_computing/sparse_linear_algebra/03-finite-difference.md
@@ -6,13 +6,13 @@ dependsOn: [
 tags: []
 attribution: 
 - citation: This material has been adapted from material by Martin Robinson from the "Scientific Computing" module of the SABS R³ Center for Doctoral Training.
-    url: https://www.sabsr3.ox.ac.uk
-    image: https://www.sabsr3.ox.ac.uk/sites/default/files/styles/site_logo/public/styles/site_logo/public/sabsr3/site-logo/sabs_r3_cdt_logo_v3_111x109.png
-    license: CC-BY-4.0
-  - citation: This course material was developed as part of UNIVERSE-HPC, which is funded through the SPF ExCALIBUR programme under grant number EP/W035731/1 
-    url: https://www.universe-hpc.ac.uk
-    image: https://www.universe-hpc.ac.uk/assets/images/universe-hpc.png
-    license: CC-BY-4.0
+  url: https://www.sabsr3.ox.ac.uk
+  image: https://www.sabsr3.ox.ac.uk/sites/default/files/styles/site_logo/public/styles/site_logo/public/sabsr3/site-logo/sabs_r3_cdt_logo_v3_111x109.png
+  license: CC-BY-4.0
+- citation: This course material was developed as part of UNIVERSE-HPC, which is funded through the SPF ExCALIBUR programme under grant number EP/W035731/1 
+  url: https://www.universe-hpc.ac.uk
+  image: https://www.universe-hpc.ac.uk/assets/images/universe-hpc.png
+  license: CC-BY-4.0
 
 
 ---

--- a/scientific_computing/sparse_linear_algebra/04-scipy-sparse.md
+++ b/scientific_computing/sparse_linear_algebra/04-scipy-sparse.md
@@ -6,13 +6,13 @@ dependsOn: [
 tags: []
 attribution: 
 - citation: This material has been adapted from material by Martin Robinson from the "Scientific Computing" module of the SABS R³ Center for Doctoral Training.
-    url: https://www.sabsr3.ox.ac.uk
-    image: https://www.sabsr3.ox.ac.uk/sites/default/files/styles/site_logo/public/styles/site_logo/public/sabsr3/site-logo/sabs_r3_cdt_logo_v3_111x109.png
-    license: CC-BY-4.0
-  - citation: This course material was developed as part of UNIVERSE-HPC, which is funded through the SPF ExCALIBUR programme under grant number EP/W035731/1 
-    url: https://www.universe-hpc.ac.uk
-    image: https://www.universe-hpc.ac.uk/assets/images/universe-hpc.png
-    license: CC-BY-4.0
+  url: https://www.sabsr3.ox.ac.uk
+  image: https://www.sabsr3.ox.ac.uk/sites/default/files/styles/site_logo/public/styles/site_logo/public/sabsr3/site-logo/sabs_r3_cdt_logo_v3_111x109.png
+  license: CC-BY-4.0
+- citation: This course material was developed as part of UNIVERSE-HPC, which is funded through the SPF ExCALIBUR programme under grant number EP/W035731/1 
+  url: https://www.universe-hpc.ac.uk
+  image: https://www.universe-hpc.ac.uk/assets/images/universe-hpc.png
+  license: CC-BY-4.0
 
 
 ---

--- a/scientific_computing/sparse_linear_algebra/06-jacobi-relaxation-methods.md
+++ b/scientific_computing/sparse_linear_algebra/06-jacobi-relaxation-methods.md
@@ -6,13 +6,13 @@ dependsOn: [
 tags: []
 attribution: 
 - citation: This material has been adapted from material by Martin Robinson from the "Scientific Computing" module of the SABS R³ Center for Doctoral Training.
-    url: https://www.sabsr3.ox.ac.uk
-    image: https://www.sabsr3.ox.ac.uk/sites/default/files/styles/site_logo/public/styles/site_logo/public/sabsr3/site-logo/sabs_r3_cdt_logo_v3_111x109.png
-    license: CC-BY-4.0
-  - citation: This course material was developed as part of UNIVERSE-HPC, which is funded through the SPF ExCALIBUR programme under grant number EP/W035731/1 
-    url: https://www.universe-hpc.ac.uk
-    image: https://www.universe-hpc.ac.uk/assets/images/universe-hpc.png
-    license: CC-BY-4.0
+  url: https://www.sabsr3.ox.ac.uk
+  image: https://www.sabsr3.ox.ac.uk/sites/default/files/styles/site_logo/public/styles/site_logo/public/sabsr3/site-logo/sabs_r3_cdt_logo_v3_111x109.png
+  license: CC-BY-4.0
+- citation: This course material was developed as part of UNIVERSE-HPC, which is funded through the SPF ExCALIBUR programme under grant number EP/W035731/1 
+  url: https://www.universe-hpc.ac.uk
+  image: https://www.universe-hpc.ac.uk/assets/images/universe-hpc.png
+  license: CC-BY-4.0
 
 
 ---

--- a/scientific_computing/sparse_linear_algebra/07-conjugate-gradient-method.md
+++ b/scientific_computing/sparse_linear_algebra/07-conjugate-gradient-method.md
@@ -6,14 +6,13 @@ dependsOn: [
 tags: []
 attribution: 
 - citation: This material has been adapted from material by Martin Robinson from the "Scientific Computing" module of the SABS R³ Center for Doctoral Training.
-    url: https://www.sabsr3.ox.ac.uk
-    image: https://www.sabsr3.ox.ac.uk/sites/default/files/styles/site_logo/public/styles/site_logo/public/sabsr3/site-logo/sabs_r3_cdt_logo_v3_111x109.png
-    license: CC-BY-4.0
-  - citation: This course material was developed as part of UNIVERSE-HPC, which is funded through the SPF ExCALIBUR programme under grant number EP/W035731/1 
-    url: https://www.universe-hpc.ac.uk
-    image: https://www.universe-hpc.ac.uk/assets/images/universe-hpc.png
-    license: CC-BY-4.0
-
+  url: https://www.sabsr3.ox.ac.uk
+  image: https://www.sabsr3.ox.ac.uk/sites/default/files/styles/site_logo/public/styles/site_logo/public/sabsr3/site-logo/sabs_r3_cdt_logo_v3_111x109.png
+  license: CC-BY-4.0
+- citation: This course material was developed as part of UNIVERSE-HPC, which is funded through the SPF ExCALIBUR programme under grant number EP/W035731/1 
+  url: https://www.universe-hpc.ac.uk
+  image: https://www.universe-hpc.ac.uk/assets/images/universe-hpc.png
+  license: CC-BY-4.0
 
 ---
 

--- a/scientific_computing/sparse_linear_algebra/index.md
+++ b/scientific_computing/sparse_linear_algebra/index.md
@@ -18,13 +18,13 @@ summary: |
   these systems efficiently.
 attribution: 
 - citation: This material has been adapted from material by Martin Robinson from the "Scientific Computing" module of the SABS R³ Center for Doctoral Training.
-    url: https://www.sabsr3.ox.ac.uk
-    image: https://www.sabsr3.ox.ac.uk/sites/default/files/styles/site_logo/public/styles/site_logo/public/sabsr3/site-logo/sabs_r3_cdt_logo_v3_111x109.png
-    license: CC-BY-4.0
-  - citation: This course material was developed as part of UNIVERSE-HPC, which is funded through the SPF ExCALIBUR programme under grant number EP/W035731/1 
-    url: https://www.universe-hpc.ac.uk
-    image: https://www.universe-hpc.ac.uk/assets/images/universe-hpc.png
-    license: CC-BY-4.0
+  url: https://www.sabsr3.ox.ac.uk
+  image: https://www.sabsr3.ox.ac.uk/sites/default/files/styles/site_logo/public/styles/site_logo/public/sabsr3/site-logo/sabs_r3_cdt_logo_v3_111x109.png
+  license: CC-BY-4.0
+- citation: This course material was developed as part of UNIVERSE-HPC, which is funded through the SPF ExCALIBUR programme under grant number EP/W035731/1 
+  url: https://www.universe-hpc.ac.uk
+  image: https://www.universe-hpc.ac.uk/assets/images/universe-hpc.png
+  license: CC-BY-4.0
 
 
 ---

--- a/software_architecture_and_design/procedural/functions_cpp.md
+++ b/software_architecture_and_design/procedural/functions_cpp.md
@@ -1,48 +1,41 @@
 ---
 name: Functions
-dependsOn: [
-    software_architecture_and_design.procedural.containers_cpp,
-]
+dependsOn: [software_architecture_and_design.procedural.containers_cpp]
 tags: [cpp]
-- citation: >
-        This material was adapted from an "Introduction to C++" course developed by the
-        Oxford RSE group.
-      url: https://www.rse.ox.ac.uk
-      image: https://www.rse.ox.ac.uk/images/banner_ox_rse.svg
-      license: CC-BY-4.0
-    - citation: This course material was developed as part of UNIVERSE-HPC, which is funded through the SPF ExCALIBUR programme under grant number EP/W035731/1 
-      url: https://www.universe-hpc.ac.uk
-      image: https://www.universe-hpc.ac.uk/assets/images/universe-hpc.png
-      license: CC-BY-4.0
-
+attribution:
+- citation: This material was adapted from an "Introduction to C++" course developed by the Oxford RSE group.
+  url: https://www.rse.ox.ac.uk
+  image: https://www.rse.ox.ac.uk/images/banner_ox_rse.svg
+  license: CC-BY-4.0
+- citation: This course material was developed as part of UNIVERSE-HPC, which is funded through the SPF ExCALIBUR programme under grant number EP/W035731/1
+  url: https://www.universe-hpc.ac.uk
+  image: https://www.universe-hpc.ac.uk/assets/images/universe-hpc.png
+  license: CC-BY-4.0
 ---
-
-
 
 # Functions
 
-The *function* (aka *procedure*) is a one of the defining aspects of proceedural programming. It
+The _function_ (aka _procedure_) is a one of the defining aspects of proceedural programming. It
 allows you to package up some code defining a particular operation into a
-re-useable *function* can can take zero or more *arguments* and (optionally)
-*return* a value.
+re-useable _function_ can can take zero or more _arguments_ and (optionally)
+_return_ a value.
 
 ## Declaring and calling funcitons
 
-The following *function prototypes* declare two functions: one called
+The following _function prototypes_ declare two functions: one called
 `my_func` that takes two parameters of type `double`{.Cpp} and returns a
 variable of type `double`{.Cpp}, and one called `main` that takes no parameters
 and returns an `int`{.Cpp}:
 
-~~~Cpp
+```Cpp
 double my_func(double x, double y);
 int main();
-~~~
+```
 
 The function prototype tells the compiler about function's name, return type,
 and parameters. You must declare the function before you can use it, like so:
 
-
-~~~Cpp
+```Cpp
 #include <iostream>
 double multiply(double x, double y); // function prototype
 
@@ -58,12 +51,11 @@ double multiply(double x, double y) // function definition
 {
   return x * y;
 }
-~~~
-
+```
 
 A function may also return no value, and be declared as `void`{.Cpp}.
 
-~~~Cpp
+```Cpp
 #include <iostream>
 void output(int score, int passMark);
 
@@ -79,36 +71,34 @@ void output(int score, int passMark) {
   else
     std::cout << "Fail - better luck next time\n";
 }
-~~~
-
+```
 
 Any variables that are used in the function must be declared as normal.
 
 For example:
 
-~~~Cpp
+```Cpp
 double multiply_by_5(double x)
 {
   double y = 5.0;
   return x * y;
 }
-~~~
+```
 
-Recall the rules about *scope*, the scope of `y` lasts until the end of the
+Recall the rules about _scope_, the scope of `y` lasts until the end of the
 function (the last curly bracket) after which `y` is removed from memory and is
 no longer available.
-
 
 ## Pass by value
 
 A function can only change the value of a variable inside the function, and not
-in the main program. This is because, by default, variables are *passed by value*, and the function
+in the main program. This is because, by default, variables are _passed by value_, and the function
 only sees a **copy**.
 
 Changes in this copied variable have no effect on the original variable, for
 example the function `no_effect` has no effect on the `x` variable passed into it in `main`:
 
-~~~Cpp
+```Cpp
 #include <iostream>
 
 void no_effect(double x) {
@@ -120,18 +110,18 @@ int main() {
   no_effect(x);
   std::cout << x << '\n';
 }
-~~~
+```
 
 [`[< compiler explorer >]`](https://gcc.godbolt.org/z/F1MBsS)
 
 # Pass by reference
 
 A common way of allowing a function to change the value of a variable outside the
-function is to use *references*. You can do this by adding 
+function is to use _references_. You can do this by adding
 the `&` symbol before the variable name in the declaration of the
 function and the prototype.
 
-~~~Cpp
+```Cpp
 #include <iostream>
 void add(double x, double y, double& rz);
 
@@ -145,7 +135,7 @@ int main() {
 void add(double x, double y, double& rz) {
   rz = x + y;
 }
-~~~
+```
 
 ::::challenge{id=swap_cpp title="Swap Two Numbers"}
 
@@ -153,6 +143,7 @@ Write a function that accepts two floating point numbers (using references), and
 swaps the values of these numbers.
 
 :::solution
+
 ```cpp
 void swap_these(float &x, float &y) {
     float tmp = x;
@@ -160,6 +151,7 @@ void swap_these(float &x, float &y) {
     y = tmp;
 }
 ```
+
 :::
 
 ::::
@@ -178,7 +170,7 @@ More than one function `mult` can be written - one that takes two
 integers and returns an integer, one that takes two floating point
 numbers and returns a floating point number, etc.
 
-~~~Cpp
+```Cpp
 float mult(float x, float y) {
   return x * y;
 }
@@ -191,7 +183,7 @@ int main() {
   int i = mult(7, 10);
   float f = mult(21.5f, 14.5f);
 }
-~~~
+```
 
 ::::challenge{id=dot_product title="Scalar (dot) product"}
 
@@ -200,6 +192,7 @@ Write a function that returns the scalar (dot) product of two
 `double` values.
 
 :::solution
+
 ```cpp
 double dot_product(const std::array<double, 3>& x, const std::array<double, 3>& y) {
     double dot = 0.0;
@@ -213,10 +206,10 @@ double dot_product(const double x, const double y) {
     return x * y;
 }
 ```
+
 :::
 
 ::::
-
 
 ## Return values
 
@@ -238,7 +231,7 @@ multiple return values via a `std::tuple`
 std::tuple<std::string, float> get_student_and_grade();
 ```
 
-or can *optionally* return value (i.e. either a value or nothing) via `std::optional`
+or can _optionally_ return value (i.e. either a value or nothing) via `std::optional`
 
 ```cpp
 std::optional<std::string> read_file_if_exists(const std::string& filename);
@@ -265,13 +258,13 @@ such a way that the caller of that function is aware of the error and can deal
 with it (if possible), or fail gracefully (perhaps clean up resources like an
 open file for example). In the previous section we saw one approach to dealling
 with an error, which is to return an optional value from the function. Another
-approach is to use C++ *exceptions*.
+approach is to use C++ _exceptions_.
 
 Let us define a function for solving a particular problem (e.g. a root-finding
 problem). This function has an input argument `x` of type `double`, but the
 solver we are writing can only solve the given problem for $x > 2.0$. Furthermore,
 even if $x > 2.0$ it is possible that the function fails to find a solution to
-the problem. 
+the problem.
 
 Since we have two possible points of failure, we decide to use exceptions to
 make the caller aware of any failures, and what in particular has gone wrong.
@@ -298,14 +291,14 @@ exceptions thrown (here either `std::invalid_argument` or `std::runtime_error`).
 If none is found then the program halts with an error.
 
 Below is an example of how you might call `solve_problem` and handle the
-possible errors with a *try-catch* expression:
+possible errors with a _try-catch_ expression:
 
 ```cpp
 int main() {
     double solve_for_x = 1.456;
     try {
         solve_problem(solve_for_x);
-    } 
+    }
     catch (std::invalid_argument err) {
         // oh no, double it and try again
         solve_problem(2 * solve_for_x);
@@ -326,8 +319,7 @@ Here we have three `catch` blocks, corresponding with different exceptions we
 want to handle. The first two are the ones we saw in the definition of
 `solve_problem`. The third is the base exception class in the standard library,
 so any exception in the standard library (or any exception derived from one of
-these) will be caught. 
-
+these) will be caught.
 
 ## Templated functions
 
@@ -337,7 +329,7 @@ differing types). Templates can be used to where the same code may need to
 repeated for different values or for different types. For example, say we had a
 function `get_min` that could accept either `double` or `int` via overloading:
 
-~~~Cpp
+```Cpp
 double get_min(double a, double b)
 {
    if (a < b) {return a;} return b;
@@ -347,13 +339,13 @@ int get_min(int a, int b)
 {
    if (a < b) {return a;} return b;
 }
-~~~
+```
 
 This is rather cumborsome as we have to repeat the implementation of the two
 overloaded functions. Instead, we can use the `template`{.Cpp} keyword to
 produce as many functions as may be required:
 
-~~~Cpp
+```Cpp
 template <typename Number>
 Number get_min (Number a, Number b) {
     if (a < b) {
@@ -367,7 +359,7 @@ int main(void) {
    double d1 = get_min<double>(22.0/7.0, 3.14159265359);
    double d2 = get_min(22.0/7.0, 3.14159265359);
 }
-~~~
+```
 
 [`[< compiler explorer >]`](https://gcc.godbolt.org/z/O5DSn8)
 
@@ -380,20 +372,20 @@ template argument `Number` replaced by the type given by the template argument.
 Note: it is not always necessary to provide the typename when calling a
 templated function, as long as the compiler can infer it:
 
-~~~Cpp
+```Cpp
 int main(void) {
    int arg1 = 10;
    int arg2 = -1;
    std::cout << get_min(arg1,arg2) << std::endl;
 }
-~~~
+```
 
 ### Multiple template arguments
 
 You can list multiple template arguments one after the other. These can be types
 (e.g. `typename T`{.Cpp}) or non-types (e.g. `int N`{.Cpp})
 
-~~~Cpp
+```Cpp
 template <int N, typename T>
 T multiply_by_n (T a) {
     return N*a;
@@ -403,23 +395,24 @@ int main(void) {
     int i = 1;
     std::cout << multiply_by_n<2>(i) << std::endl;
 }
-~~~
+```
 
 ::::challenge{id=dot_product_cont title="Scalar (dot) product continued"}
 
 Rewrite your dot product function to take any two containers $a$ and $b$ that follow the standard container interface in C++. Your function should take three arguments:
 
-1. A start iterator for vector $a$ 
-1. An end iterator for vector $a$ 
+1. A start iterator for vector $a$
+1. An end iterator for vector $a$
 1. A start iterator for vector $b$ (vector $b$ is assumed to be the same size as vector $a$)
 
 Template your function on the iterator type for $a$ `Ta`, and the iterator type
 for $b$ `Tb`. If you like, you can perform the calculation of the dot product
 using a fixed type `double`. For an extra challenge, make sure you use the same
 type contained in $a$ (hint: each iterator and container in the standard library
-has a subtype `value_type` that is the value type held by the container). 
+has a subtype `value_type` that is the value type held by the container).
 
 :::solution
+
 ```cpp
 template <typename Ta, typename Tb>
 Ta::value_type dot_product(Ta start_a, Ta end_a, Tb start_b) {
@@ -433,6 +426,6 @@ Ta::value_type dot_product(Ta start_a, Ta end_a, Tb start_b) {
 }
 
 ```
+
 :::
 ::::
-

--- a/software_architecture_and_design/procedural/variables_cpp.md
+++ b/software_architecture_and_design/procedural/variables_cpp.md
@@ -1,21 +1,18 @@
 ---
 name: Variables
-dependsOn: [
-    technology_and_tooling.bash_shell.bash,
-    technology_and_tooling.ide.cpp,
-]
+dependsOn: [technology_and_tooling.bash_shell.bash, technology_and_tooling.ide.cpp]
 tags: [cpp]
-- citation: >
-        This material was adapted from an "Introduction to C++" course developed by the
-        Oxford RSE group.
-      url: https://www.rse.ox.ac.uk
-      image: https://www.rse.ox.ac.uk/images/banner_ox_rse.svg
-      license: CC-BY-4.0
-    - citation: This course material was developed as part of UNIVERSE-HPC, which is funded through the SPF ExCALIBUR programme under grant number EP/W035731/1 
-      url: https://www.universe-hpc.ac.uk
-      image: https://www.universe-hpc.ac.uk/assets/images/universe-hpc.png
-      license: CC-BY-4.0
-
+attribution:
+  - citation: >
+      This material was adapted from an "Introduction to C++" course developed by the
+      Oxford RSE group.
+    url: https://www.rse.ox.ac.uk
+    image: https://www.rse.ox.ac.uk/images/banner_ox_rse.svg
+    license: CC-BY-4.0
+  - citation: This course material was developed as part of UNIVERSE-HPC, which is funded through the SPF ExCALIBUR programme under grant number EP/W035731/1
+    url: https://www.universe-hpc.ac.uk
+    image: https://www.universe-hpc.ac.uk/assets/images/universe-hpc.png
+    license: CC-BY-4.0
 ---
 
 ## Getting started
@@ -32,40 +29,40 @@ code .
 
 Ensure that you have the `clang` cpp compiler installed using:
 
-~~~bash
+```bash
 clang++ --version
-~~~
+```
 
 You should see something like:
 
-~~~
+```
 Homebrew clang version 15.0.3
 Target: x86_64-apple-darwin22.1.0
 Thread model: posix
 InstalledDir: /usr/local/opt/llvm/bin
-~~~
+```
 
 Check where the compiler executable is located on your machine
 
-~~~bash
+```bash
 which clang++
-~~~
+```
 
 You should see something like:
 
-~~~
+```
 /usr/local/opt/llvm/bin/clang++
-~~~
+```
 
 Create a new file `prodedural.cpp` and copy in the following contents:
 
-~~~cpp
+```cpp
 #include <iostream>
 
 int main() {
     std::cout << "hello world" << std::endl;
 }
-~~~
+```
 
 Open the command palette and choose "C/C++ Run C/C++ File", or click on the play
 button in the top right hand corner of the screen. Choose the clang compiler
@@ -79,38 +76,38 @@ debug console.
 
 Variables in C++ must be declared with their type, before they are used, for example:
 
-~~~cpp
+```cpp
 int six = 2 * 3;
 std::cout << "six = " << six << std::endl;
-~~~
+```
 
-~~~
+```
 six = 6
-~~~
+```
 
 The compiler must be able to determine the type of every variable when it
-compiles your code. This is a characteristic of *statically typed* languages. It
+compiles your code. This is a characteristic of _statically typed_ languages. It
 uses this type when working out how much memory to allocate for the value (in
-this case the number 6), and to determine the format for *how* this value is
+this case the number 6), and to determine the format for _how_ this value is
 stored in memory. For example, consulting a reference webpage like
 [this](https://en.cppreference.com/w/cpp/language/types) tells us that the `int`
 type is at least 16 bits in size, each bit can be either 0 or 1, and so the
 value 6 will be stored in these 16 bits as the binary number 0000000000000110.
-In this case `int` is a *signed* type, and the first bit is 0 for positive, and
+In this case `int` is a _signed_ type, and the first bit is 0 for positive, and
 1 for negative values, so -6 will be represented as 1000000000000110.
 
-So the *type* of a variable tells the compiler how to interpret the data stored
+So the _type_ of a variable tells the compiler how to interpret the data stored
 in memory to arrive at a value for our variable `six`. Simliarly, it tells the
-compiler what format to *write* to memory when the value of the variable is
+compiler what format to _write_ to memory when the value of the variable is
 changed.
 
 If we try to use a variable that hasn't been defined, we get a compiler error:
 
-~~~cpp
+```cpp
 int seven = sixe + 1;
-~~~
+```
 
-~~~
+```
 /Users/martinjrobins/git/thing/procedural.cpp:7:17: error: use of undeclared identifier 'sixe'; did you mean 'six'?
     int seven = sixe + 1;
                 ^~~~
@@ -119,10 +116,10 @@ int seven = sixe + 1;
     int six = 2 * 3;
         ^
 1 error generated.
-~~~
+```
 
 Note here we accidentally wrote `sixe` instead of `six`, so the compiler
-recognised this as an *undeclared identifier* and gave an error. It even
+recognised this as an _undeclared identifier_ and gave an error. It even
 helpfully identified a variable with a similar name that you might have meant.
 This highlights one of the advantages of a compiler, it can catch a range of
 errors before you even run your program, which can be very useful if you have a
@@ -130,16 +127,16 @@ large project that takes a significant time to run.
 
 If we know that a variable will be constant, we can indicate this using the `const` keyword, like so:
 
-~~~cpp
+```cpp
 const int six = 2 * 3;
-~~~
+```
 
 This has the advantage that if we try and modify `six` later on, the compiler will inform us of our error:
 
-~~~cpp
+```cpp
 const int six = 2 * 3;
 six = 7;
-~~~
+```
 
 ```
 /Users/martinjrobins/git/thing/procedural.cpp:8:9: error: cannot assign to variable 'six' with const-qualified type 'const int'
@@ -153,7 +150,7 @@ expect to the constant with `const`.
 
 ### Blocks and scope
 
-A C++ program is made up of many *blocks* which are delimited by curly brackets.
+A C++ program is made up of many _blocks_ which are delimited by curly brackets.
 As an example, lets define a `main` function with a `for` loop inside. The curly
 brackets after the `main` function delimite an outer block, whereas the curly
 brackets after the `for` loop delimite an inner block.
@@ -169,12 +166,11 @@ int main() {
 }
 ```
 
-Each variable has a particular block *scope* where it is valid, which starts
+Each variable has a particular block _scope_ where it is valid, which starts
 where the variable is declared and covers to the end of the current block,
 including any inner blocks. In the example above, the `two` variable is in
 scope until the end of the main function. However, the `i` and `x` variables
 are only in scope until the end of the `for` loop.
-
 
 ::::challenge{id=scope title="Largest Circumference"}
 
@@ -195,9 +191,8 @@ for (int i = 0; i < 10; i++) {
 std::cout << "largest circumference is " << circumference << std::endl;
 ```
 
-
 :::callout
-In this snippet we *cast* the integer `i` to the floating point number `radius`,
+In this snippet we _cast_ the integer `i` to the floating point number `radius`,
 this is a way of converting between different types in C++. You will learn more
 about type conversions later in this section
 :::
@@ -216,6 +211,7 @@ for (int i = 0; i < 10; i++) {
 }
 std::cout << "largest circumference is " << circumference << std::endl;
 ```
+
 :::
 
 However, this code assumes that the largest circumference is computed last. You
@@ -238,16 +234,15 @@ std::cout << "largest circumference is " << largest_circumference << std::endl;
 
 ::::
 
-
 ### Floating point numbers
 
 Lets declare a floating point number in C++:
 
-~~~cpp
+```cpp
 const float weight_kg = 55.0;
 const float weight_lb = 2.2 * weight_kg;
 std::cout << "Weight in lb " << weight_lb << std::endl;
-~~~
+```
 
 The useful resource
 [cppreference](https://en.cppreference.com/w/cpp/language/types) tells us that
@@ -258,7 +253,7 @@ is very different to the format used to store an `int`.
 
 Note that literals like `55.0` also have a type in C++, and it is a good rule of
 thumb to be consistent with your types. Writing something like `float weight_kg
-= 55` is actually assigning an integer to a float and involves an *implicit*
+= 55` is actually assigning an integer to a float and involves an _implicit_
 type conversion. In this case there is no harm done, but implicit type
 conversions are a source of bugs and should be avoided.
 
@@ -266,34 +261,34 @@ Note that you can, and should, be even more explicit in type of literal you are 
 specify it using a
 [suffix](https://en.cppreference.com/w/cpp/language/floating_literal):
 
-~~~cpp
+```cpp
 const float weight_kg = 55.0f;
 const float weight_lb = 2.2f * weight_kg;
 std::cout << "Weight in lb " << weight_lb << std::endl;
-~~~
+```
 
 Now we have specified that all the literals are `float` (as opposed to
 `double`, which is a 64 bit floating point type in C++). Writing the same code
 using `double` looks like this:
 
-~~~cpp
+```cpp
 const double weight_kg = 55.0;
 const double weight_lb = 2.2 * weight_kg;
 std::cout << "Weight in lb " << weight_lb << std::endl;
-~~~
+```
 
 ## Strings
 
-Thus far we have been using only the *fundamental types* in C++. And we've only
+Thus far we have been using only the _fundamental types_ in C++. And we've only
 touched on a couple of these, you can see a more thoughor list
 [here](https://en.cppreference.com/w/cpp/language/types).
 
-Like in many languages, C++ allows you to define *classes*. These are
-user-defined types that contain data in the form of *member variables* (in
+Like in many languages, C++ allows you to define _classes_. These are
+user-defined types that contain data in the form of _member variables_ (in
 Python we call these "properties" or "attributes"), and functions that operate
-on that data in the form of *member functions* (in Python these are called
+on that data in the form of _member functions_ (in Python these are called
 "methods"). This follows a different programming paradigm known as
-*object-orientated* programming, or OO. We won't cover OO much in this course,
+_object-orientated_ programming, or OO. We won't cover OO much in this course,
 but since many useful standard types in C++ are defined as classes in the C++
 standard library you need to be aware how to use classes in C++.
 
@@ -303,10 +298,10 @@ are a way to group together a number of related functions, types and classes in
 such a way that their names do not conflict with functions/types/classes in
 other namespaces. E.g. `std::string` refers to a different class than
 `my_namespace::string`. The `std::string` class is defined in the `string`
-header file, so before we use it we need to *include* this header in our source
+header file, so before we use it we need to _include_ this header in our source
 file (at the top of the file above our `main` function):
 
-~~~cpp
+```cpp
 #include <iostream>
 #include <string>
 
@@ -317,16 +312,16 @@ int main() {
     std::string full = given + " " + middle + " " + family;
     std::cout << full << std::endl;
 }
-~~~
+```
 
-~~~
+```
 Joe Frederick 'Bloggs'
-~~~
+```
 
 As with strings in Python, we can use the `+` operator to concatenate two C++
 strings together. However, we can only use double quotes for strings in C++, as
 single quotes are reserved for characters. To include the single quotes in our
-string, we use the backslash to *escape* the normal meaning of the single quote
+string, we use the backslash to _escape_ the normal meaning of the single quote
 character.
 
 ## References
@@ -335,36 +330,36 @@ Previously we explained that variables in Python are only labels for a "box", or
 section of memory, that holds a value. You can therefore have multiple labels
 for the same box. In C++ a variables is the box itself, each variables is
 assigned a given section of memory where the value is stored according to its
-type. You can obtain the address, or *pointer*, to the start of this section of
-memory by using the *address-of* operator `&`. We can obtain the original
-variable by using the *dereferencing* operator `*`.
+type. You can obtain the address, or _pointer_, to the start of this section of
+memory by using the _address-of_ operator `&`. We can obtain the original
+variable by using the _dereferencing_ operator `*`.
 
-~~~cpp
+```cpp
 int *p_six = &six;
 std::cout << "six = *p_six" << std::endl;
-~~~
+```
 
 Note that the type of `p_six` is a pointer to an `int`, denoted as `int *`. On a
 64-bit operating system, all pointer types are stored in 64 bits of memory. You
 might think that this pointer is similar to a label, or Python variable, but a
 raw pointer like this is much more low-level and potentially dangerous than
 this, and you should generally avoid creating them. Instead, C++ features a wide
-variety of [*smart
-pointers*](https://en.cppreference.com/book/intro/smart_pointers) that you
+variety of [_smart
+pointers_](https://en.cppreference.com/book/intro/smart_pointers) that you
 should use instead (a variable in Python is most closely related to a
 `std::shared_pointer`). However, all of these pointers share simliar semantics
-in that a pointer can point to nothing, otherwise known as a *null pointer* and
-represented in C++ by the literal `nullptr`. 
+in that a pointer can point to nothing, otherwise known as a _null pointer_ and
+represented in C++ by the literal `nullptr`.
 
 Generally, you should not use pointers unless you need to worry about allocating
 memory (e.g. you are writing a custom data structure). A more useful
 label-to-a-box in C++ that must point to a valid memory location is provided by
-a *reference*. This is similar to a pointer in that it is a label to a box
-(rather than *being* that box), and therefore you can have multiple references
+a _reference_. This is similar to a pointer in that it is a label to a box
+(rather than _being_ that box), and therefore you can have multiple references
 to the same box. But you can use it in the same way you would the original
 variable. The type of a reference to an `int` is given by `int &`, so:
 
-~~~cpp
+```cpp
 int &r_number = six;
 int &r_number2 = six;
 std::cout << "six = " << r_number << std::endl;
@@ -372,14 +367,14 @@ r_number += 1;
 std::cout << "seven = " << r_number << std::endl;
 std::cout << "seven = " << r_number2 << std::endl;
 std::cout << "seven = " << six << std::endl;
-~~~
+```
 
-~~~
+```
 six = 6
 seven = 7
 seven = 7
 seven = 7
-~~~
+```
 
 ::::challenge{id=pointers title="Getting used references"}
 
@@ -390,22 +385,24 @@ value by printing it out.
 Try and mark `d` as `const` and see what the compiler tells you.
 
 :::solution
+
 ```cpp
 double d = 5.0;
 double& r_d = d;
 r_d = 6.0
 std::cout << d << std::endl;
 ```
+
 :::
 
 ::::
 
-There are two types of references in C++, *lvalue* and *rvalue* references.
+There are two types of references in C++, _lvalue_ and _rvalue_ references.
 Above we have used lvalue references, which are so-called because they can only
-be *bound* to an lvalue, such as a variable or element of a container (i.e.
+be _bound_ to an lvalue, such as a variable or element of a container (i.e.
 anything
- that you could put on the left hand side of an assignment `=`
-statement). An lvalue reference is declared using a single `&`. 
+that you could put on the left hand side of an assignment `=`
+statement). An lvalue reference is declared using a single `&`.
 
 ```cpp
 int six = 6;
@@ -421,10 +418,9 @@ assignment `=` statement). An rvalue reference is declared using two ampersands 
 int&& rr_six = 6;
 ```
 
-Rvalue references are commonly used to enable *move semantics* in C++. You
+Rvalue references are commonly used to enable _move semantics_ in C++. You
 often want to write code that minimises the number of copies, for example say
 you wished to swap the values of two (large) strings `war_and_peace` and `moby_dick`.
-
 
 ```cpp
 T tmp(war_and_peace);
@@ -447,16 +443,15 @@ variable `b`, without the requiriment of maintaining the value of `a`. Note that
 after we have moved `a` its value is now unspecified, so after the last
 statement in the snippet above, the value of `tmp` will be unspecified.
 
-
 ### Optional types
 
 What if you wish to represent a variable that could be a value or could be
-*nothing*? For example perhaps you have a function that takes as argument a
+_nothing_? For example perhaps you have a function that takes as argument a
 string and finds the first word beginning with the letter `a`. What should it
 return if the string does not contain `a`?
 
 Other languages have an inbuilt concept of nothing, for example the `None` value
-in Python. In C++ you can instead define an *optional* type that could have a value, or not. If we have a function `find_first_word_starting_with_a` that returns an optional string type we can use it like so:
+in Python. In C++ you can instead define an _optional_ type that could have a value, or not. If we have a function `find_first_word_starting_with_a` that returns an optional string type we can use it like so:
 
 ```cpp
 const std::optional<std::string> word = find_first_word_starting_with_a(my_string);
@@ -468,27 +463,26 @@ if (word) {
 ```
 
 Th angle brackets indicate that `std::optional` is a templated class. The first
-and only *template argument* is `std::string`, meaning that
+and only _template argument_ is `std::string`, meaning that
 `std::optional<std::string>` is an optional `std::string` type. Templates in C++
 enable yet another programming paradigm called
-*generic programming*. As you can see, there are a number of different
+_generic programming_. As you can see, there are a number of different
 programming paradigms, all with their own uses! It is best to be aware of and
 use all of them interchangably for the problem at hand or the idea you wish to
-express. 
+express.
 
 ### Converting Between Types with C++
-
 
 Conversion between types in C++ can occur implicitly, or explicitly. You should
 always strive to be as explicit as possible in any code you write. Code is meant
 to be read, and the most important reader is another human (a computer probably
 would prefer it if you just wrote assembly!), so be as clear and as explicit as
-you can when you write your code. 
+you can when you write your code.
 
 Unfortunately, implicit conversions can occur quite easily in C++, and this is a
 source of many bugs. For example:
 
-~~~cpp
+```cpp
 const double x = std::atan(1.0d) * 4.0d;
 const float y = x;
 if (y == x) {
@@ -496,7 +490,7 @@ if (y == x) {
 } else {
     std::cout << "x != y" << std::endl;
 }
-~~~
+```
 
 In this case the value of x, represented by a `double` type, is close to the
 mathematical constant pi. The variable `y` is of type `float`, and so the assignment
@@ -505,13 +499,13 @@ be represented by a `float`, according to the rules dictated
 [here](https://en.cppreference.com/w/cpp/language/implicit_conversion). Since
 the value now in `y` is different to the value in `x`, the result is:
 
-~~~
+```
 x != y
-~~~
+```
 
 Let's instead write the conversion between `double` and `float` explicitly using `static_cast`.
 
-~~~cpp
+```cpp
 const double x = std::atan(1.0d) * 4.0d;
 const float y = static_cast<float>(x);
 if (y == x) {
@@ -519,15 +513,15 @@ if (y == x) {
 } else {
     std::cout << "x != y" << std::endl;
 }
-~~~
+```
 
 Not only have we highlighted that a conversion occurs, the very act of writing
 the `static_cast` has forced us to think about the conversion and its
-implications. 
+implications.
 
 Here is another example of a potential bug (and use-case for `static_cast`):
 
-~~~cpp
+```cpp
 const int n = 100;
 std::vector<double> vec(n, 1.0);
 const double rn = 1 / n;
@@ -536,14 +530,14 @@ for (size_t i = 0; i < n; i++) {
     mean += rn * vec[i];
 }
 std::cout << "mean is " << mean << std::endl;
-~~~
+```
 
 Here we are creating a vector of `double` with all the elements initialised to
 1.0. This program outputs:
 
-~~~
+```
 mean is 0
-~~~
+```
 
 What has happened? In this case, we have heard somewhere that multiplications
 are cheaper to compute than division, so we have attempted to optimise the loop
@@ -552,43 +546,46 @@ have introduced two mistakes on the line `const double rn = 1 / n;`. Both the
 '1' and `n` here should be of type `double`, not `int`, so that the division is
 a floating-point division rather than integer division. Instead this should be:
 
-~~~cpp
+```cpp
 const double rn = 1.0 / static_cast<double>(n);
-~~~
+```
 
 to get the behaviour we are expecting.
 
-Recall, these are fairly tame example using fundamental types.  However, once
+Recall, these are fairly tame example using fundamental types. However, once
 you start creating your own types via classes the opportunities for implicit
 conversions to introduce subtle bugs increases exponentially, so a good rule of
-thumb is to discourage implicit casts and to *always* be explicit. 
+thumb is to discourage implicit casts and to _always_ be explicit.
 
 ::::challenge{id=cpp_calculate_pi title="Calculating PI"}
 
 Create two `double` variables $x$ and $y$. Set $x=0.3$ and $y=0.4$ and
 calculate $r = \sqrt{x^2 + y^2}$. Write the result $r$ to the console using
 `std::cout`. Note that C++ has library functions `std::sqrt` and `std::pow` for
-square root and power. You can see the cpp-reference page for `std::sqrt` [here](https://en.cppreference.com/w/cpp/numeric/math/sqrt). 
+square root and power. You can see the cpp-reference page for `std::sqrt` [here](https://en.cppreference.com/w/cpp/numeric/math/sqrt).
 
 :::solution
-~~~cpp
+
+```cpp
 const double x = 0.3;
 const double y = 0.4;
 
 const double r = std::sqrt(std::pow(x,2) + std::pow(y,2));
 
 std::cout << "r = "<< r << std::endl;
-~~~
+```
+
 :::
 
 Generate $N$ uniform random numbers $x_i$ and $y_i$ between -1 and 1 using
 `std::uniform_real_distribution` (see example of use
 [here](https://en.cppreference.com/w/cpp/numeric/random/uniform_real_distribution)).
-Count 
-the number of points where $\sqrt{x_i^2 + y_i^2} < 1$, and use this to 
+Count
+the number of points where $\sqrt{x_i^2 + y_i^2} < 1$, and use this to
 estimate the value of $\pi$.
 
 :::solution
+
 ```cpp
 std::default_random_engine generator;
 std::uniform_real_distribution<double> uniform(-1.0,1.0);
@@ -606,11 +603,11 @@ for (int i = 0; i < N; ++i) {
 
 std::cout << "pi is about "<< 4.0*static_cast<double>(count)/static_cast<double>(N) << std::endl;
 ```
+
 :::
 
-
-Code up another estimator for $\pi$ by calculating the sum of the reciprocals 
-of square numbers (The Basel problem) for $N$ terms, which converges to 
+Code up another estimator for $\pi$ by calculating the sum of the reciprocals
+of square numbers (The Basel problem) for $N$ terms, which converges to
 $\pi^2/6$ for large enough $N$.
 
 $$
@@ -618,14 +615,16 @@ S = \sum_{n=1}^{n=N} \frac{1}{n^2} \rightarrow \frac{\pi^2}{6}
 $$
 
 :::solution
-~~~cpp
+
+```cpp
 const int N = 1000;
 double sum = 0.0;
 for (int i = 1; i < N; ++i) {
   sum += 1.0/static_cast<double>(std::pow(i,2));
 }
 std::cout << "pi is about "<< std::sqrt(6.0*sum) << std::endl;
-~~~
+```
+
 :::
 
 ::::


### PR DESCRIPTION
#107 contained a lot of invalid yaml which breaks Gutenberg (as front matters can't parse the invalid yaml), indeed github does flag this as invalid also so we should be able to build a system which automatically checks this for us.

see e.g. https://github.com/OxfordRSE/gutenberg/actions/runs/9347702886/job/25725250389

This PR fixes all the invalid yaml, I forgot to turn off my md linting so it made some automatic changes too on some cpp course and I cant be bothered manually reverting it.



