### PR TITLE
remove fix option md lint

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -37,4 +37,4 @@ jobs:
         run: npm install -g markdownlint-cli
 
       - name: Lint Markdown files
-        run: markdownlint -f  '**/*.md' --ignore '*/*/slides/*' --ignore README.md
+        run: markdownlint '**/*.md' --ignore '*/*/slides/*' --ignore README.md

--- a/technology_and_tooling/packaging_dependency_management/pack_python_04sharing.md
+++ b/technology_and_tooling/packaging_dependency_management/pack_python_04sharing.md
@@ -180,13 +180,14 @@ rendering the latter format obsolete. For more information, refer to [Wheel vs E
     python -m build --wheel
     ```
 
-5.  Install the wheel using `pip`. Wheels are written in the `dist/` directory, just
+5. Install the wheel using `pip`. Wheels are written in the `dist/` directory, just
     like source distributions.
 
     ```shell
     python -m pip install ./dist/tstools*.whl
     ```
-6.  `.whl` files are basically zip files. Unzip the wheel and explore its contents.
+
+6. `.whl` files are basically zip files. Unzip the wheel and explore its contents.
 
 :::callout
 The [wheel](https://pypi.org/project/wheel/) package is a built-in extension to the `setuptools` package.


### PR DESCRIPTION
I suddenly realised that i left a fix flag in which would stop autofixable errors from being caught.