### PR TITLE
Only lint on push to main

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -2,6 +2,8 @@ name: Check Markdown and Front Matter
 
 on:
   push:
+    branches:
+      - main
     paths:
       - '**/*.md'
   pull_request:


### PR DESCRIPTION
Prevent the workflow running twice every time a push updates a PR.