### PR TITLE
[Revamp] Workflows with Snakemake

### DIFF
--- a/technology_and_tooling/snakemake/additional_features.md
+++ b/technology_and_tooling/snakemake/additional_features.md
@@ -68,17 +68,18 @@ modules**. For this, Snakemake provides the `include` directive to
 include another Snakefile into the current one, e.g.:
 
 ```yaml
-include: "path/to/other.snakefile"
+include: "path/to/other.smk"
 ```
 
-Alternatively, Snakemake allows to **define sub-workflows**. A
+As can be seen, the default file extensions for snakefiles other than the main snakefile is `.smk`.
+Alternatively, Snakemake allows to **define external workflows as modules**. A
 sub-workflow refers to a working directory with a complete Snakemake
 workflow. Output files of that sub-workflow can be used in the current
 Snakefile. When executing, Snakemake ensures that the output files of
 the sub-workflow are up-to-date before executing the current workflow.
 This mechanism is particularly useful when you want to extend a previous
 analysis without modifying it. For details about sub-workflows, see the
-`documentation <snakefiles-sub_workflows>`{.interpreted-text
+`documentation <snakefiles-modularization>`{.interpreted-text
 role="ref"}.
 
 ::::challenge{id=add_include title="Exercise"}
@@ -136,7 +137,13 @@ snakefile.
 When Snakemake is executed with
 
 ```console
-snakemake --use-conda --cores 1
+snakemake --software-deployment-method conda --cores 1
+```
+
+or the short form
+
+```console
+snakemake --sdm conda -c 1
 ```
 
 it will automatically create required environments and activate them
@@ -188,137 +195,13 @@ in the repository. These can be looked up in the corresponding
 [database](https://snakemake-wrappers.readthedocs.io). The first part of
 the URL is a Git version tag. Upon invocation, Snakemake will
 automatically download the requested version of the wrapper.
-Furthermore, in combination with `--use-conda` (see
+Furthermore, in combination with `--software-deployment-method conda` (see
 `tutorial-conda`{.interpreted-text role="ref"}), the required software
 will be automatically deployed before execution.
 
-## Cluster execution
+## Cluster or cloud execution
 
-By default, Snakemake executes jobs on the local machine it is invoked
-on. Alternatively, it can execute jobs in **distributed environments,
-e.g., compute clusters or batch systems**. If the nodes share a common
-file system, Snakemake supports three alternative execution modes.
-
-In cluster environments, compute jobs are usually submitted as shell
-scripts via commands like `qsub`. Snakemake provides a **generic mode**
-to execute on such clusters. By invoking Snakemake with
-
-```console
-snakemake --cluster qsub --jobs 100
-```
-
-each job will be compiled into a shell script that is submitted with the
-given command (here `qsub`). The `--jobs` flag limits the number of
-concurrently submitted jobs to 100. This basic mode assumes that the
-submission command returns immediately after submitting the job. Some
-clusters allow to run the submission command in **synchronous mode**,
-such that it waits until the job has been executed. In such cases, we
-can invoke e.g.
-
-```console
-snakemake --cluster-sync "qsub -sync yes" --jobs 100
-```
-
-The specified submission command can also be **decorated with additional
-parameters taken from the submitted job**. For example, the number of
-used threads can be accessed in braces similarly to the formatting of
-shell commands, e.g.
-
-```console
-snakemake --cluster "qsub -pe threaded {threads}" --jobs 100
-```
-
-Alternatively, Snakemake can use the Distributed Resource Management
-Application API ([DRMAA](https://www.drmaa.org)). This API provides a
-common interface to control various resource management systems. The
-**DRMAA support** can be activated by invoking Snakemake as follows:
-
-```console
-snakemake --drmaa --jobs 100
-```
-
-If available, **DRMAA is preferable over the generic cluster modes**
-because it provides better control and error handling. To support
-additional cluster specific parametrization, a Snakefile can be
-complemented by a `snakefiles-cluster_configuration`{.interpreted-text
-role="ref"} file.
-
-## Using \--cluster-status
-
-Sometimes you need specific detection to determine if a cluster job
-completed successfully, failed or is still running. Error detection with
-`--cluster` can be improved for edge cases such as timeouts and jobs
-exceeding memory that are silently terminated by the queueing system.
-This can be achieved with the `--cluster-status` option. The value of
-this option should be a executable script which takes a job id as the
-first argument and prints to stdout only one of \[runningfailed\].
-Importantly, the job id snakemake passes on is captured from the stdout
-of the cluster submit tool. This string will often include more than the
-job id, but snakemake does not modify this string and will pass this
-string to the status script unchanged. In the situation where snakemake
-has received more than the job id these are 3 potential solutions to
-consider: parse the string received by the script and extract the job id
-within the script, wrap the submission tool to intercept its stdout and
-return just the job code, or ideally, the cluster may offer an option to
-only return the job id upon submission and you can instruct snakemake to
-use that option. For sge this would look like
-`snakemake --cluster "qsub -terse"`.
-
-The following (simplified) script detects the job status on a given
-SLURM cluster (\>= 14.03.0rc1 is required for `--parsable`).
-
-```python
-import subprocess
-import sys
-
-jobid = sys.argv[1]
-
-output = str(subprocess.check_output("sacct -j %s --format State --noheader | head -1 | awk '{print $1}'" % jobid, shell=True).strip())
-
-running_status=["PENDING", "CONFIGURING", "COMPLETING", "RUNNING", "SUSPENDED"]
-if "COMPLETED" in output:
-    print("success")
-elif any(r in output for r in running_status):
-    print("running")
-else:
-    print("failed")
-```
-
-To use this script call snakemake similar to below, where `status.py` is
-the script above.
-
-```console
-snakemake all --jobs 100 --cluster "sbatch --cpus-per-task=1 --parsable" --cluster-status ./status.py
-```
-
-## Using \--cluster-cancel
-
-When snakemake is terminated by pressing `Ctrl-C`, it will cancel all
-currently running node when using `--drmaa`. You can get the same
-behaviour with `--cluster` by adding `--cluster-cancel` and passing a
-command to use for canceling jobs by their jobid (e.g., `scancel` for
-SLURM or `qdel` for SGE). Most job schedulers can be passed multiple
-jobids and you can use `--cluster-cancel-nargs` to limit the number of
-arguments (default is 1000 which is reasonable for most schedulers).
-
-## Using \--cluster-sidecar
-
-In certain situations, it is necessary to not perform calls to cluster
-commands directly and instead have a \"sidecar\" process, e.g.,
-providing a REST API. One example is when using SLURM where regular
-calls to `scontrol show job JOBID` or `sacct -j JOBID` puts a high load
-on the controller. Rather, it is better to use the `squeue` command with
-the `-i/--iterate` option.
-
-When using `--cluster`, you can use `--cluster-sidecar` to pass in a
-command that starts a sidecar server. The command should print one line
-to stdout and then block and accept connections. The line will
-subsequently be available in the calls to `--cluster`,
-`--cluster-status`, and `--cluster-cancel` in the environment variable
-`SNAKEMAKE_CLUSTER_SIDECAR_VARS`. In the case of a REST server, you can
-use this to return the port that the server is listening on and
-credentials. When the Snakemake process terminates, the sidecar process
-will be terminated as well.
+Executing jobs on a cluster or in the cloud is supported by so-called executor plugins, which are distributed and documented via the [Snakemake plugin catalog](https://snakemake.github.io/snakemake-plugin-catalog).
 
 ## Constraining wildcards
 

--- a/technology_and_tooling/snakemake/advanced.md
+++ b/technology_and_tooling/snakemake/advanced.md
@@ -169,20 +169,6 @@ rule bwa_map:
         "bwa mem -t {threads} {input} | samtools view -Sb - > {output}"
 ```
 
-:::callout
-
-Snakemake does not automatically rerun jobs when new input files are
-added as in the excercise below. However, you can get a list of output
-files that are affected by such changes with
-`snakemake --list-input-changes`. To trigger a rerun, this bit of bash
-magic helps:
-
-```console
-snakemake -n --forcerun $(snakemake --list-input-changes)
-```
-
-:::
-
 Any normal function would work as well. Input functions take as **single
 argument** a `wildcards` object, that allows to access the wildcards
 values via attributes (here `wildcards.sample`). They have to **return a
@@ -369,6 +355,8 @@ deleted by accident.
   You will see that it fails (as intended) because Snakemake cannot
   overwrite the protected output files.
 
+After having a look at the summary, please go on with the [“additional features” part of the tutorial](additional_features).
+
 ::::
 
 ## Summary
@@ -459,3 +447,5 @@ rule plot_quals:
     script:
         "scripts/plot-quals.py"
 ```
+
+Now, please go on with the [“additional features” part of the tutorial](additional_features).

--- a/technology_and_tooling/snakemake/basics.md
+++ b/technology_and_tooling/snakemake/basics.md
@@ -75,10 +75,10 @@ Our first Snakemake rule maps reads of a given sample to a given
 reference genome (see `tutorial-background`). For this, we will use the tool
 [bwa](http://bio-bwa.sourceforge.net), specifically the subcommand
 `bwa mem`. In the working directory, **create a new file** called
-`Snakefile` with an editor of your choice. We propose to use the
-[Atom](https://atom.io) editor, since it provides out-of-the-box syntax
-highlighting for Snakemake. In the Snakefile, define the following rule:
-
+`Snakefile` with an editor of your choice. We propose to use the integrated development
+environment (IDE) tool Visual Studio Code, since it provides a good syntax highlighting
+Snakemake extension and a remote extension for directly using the IDE on a remote
+server. In the Snakefile, define the following rule:
 ```snakemake
 rule bwa_map:
     input:

--- a/technology_and_tooling/snakemake/basics.md
+++ b/technology_and_tooling/snakemake/basics.md
@@ -452,7 +452,7 @@ samples.
 obtain the updated DAG of jobs for the target file `calls/all.vcf`,
 it should look like this:
 
-![updated DAG](workflows/dag_call.png)
+![updated DAG](workflow/dag_call.png)
 
 ::::
 

--- a/technology_and_tooling/snakemake/basics.md
+++ b/technology_and_tooling/snakemake/basics.md
@@ -590,6 +590,8 @@ influence the DAG of jobs**.
   `--forcerun` flag in combination with some rulename) to understand
   the decisions of Snakemake.
 
+After having a look at the summary, please go on with the [advanced part of the tutorial](advanced).
+
 ::::
 
 ## Summary
@@ -654,3 +656,5 @@ rule plot_quals:
     script:
         "scripts/plot-quals.py"
 ```
+
+Now, please go on with the [advanced part of the tutorial](advanced).

--- a/technology_and_tooling/snakemake/basics.md
+++ b/technology_and_tooling/snakemake/basics.md
@@ -79,6 +79,7 @@ reference genome (see `tutorial-background`). For this, we will use the tool
 environment (IDE) tool Visual Studio Code, since it provides a good syntax highlighting
 Snakemake extension and a remote extension for directly using the IDE on a remote
 server. In the Snakefile, define the following rule:
+
 ```snakemake
 rule bwa_map:
     input:

--- a/technology_and_tooling/snakemake/basics.md
+++ b/technology_and_tooling/snakemake/basics.md
@@ -385,7 +385,7 @@ list of samples `SAMPLES`, i.e.
 The function is particularly useful when the pattern contains multiple
 wildcards. For example,
 
-```sn akemake
+```snakemake
 expand("sorted_reads/{sample}.{replicate}.bam", sample=SAMPLES, replicate=[0, 1])
 ```
 
@@ -495,7 +495,7 @@ like `input`, `output`, `wildcards`, etc. are available as attributes of
 a global `snakemake` object. Create the file `scripts/plot-quals.py`,
 with the following content:
 
-```python
+```snakemake
 import matplotlib
 matplotlib.use("Agg")
 import matplotlib.pyplot as plt

--- a/technology_and_tooling/snakemake/basics.md
+++ b/technology_and_tooling/snakemake/basics.md
@@ -500,7 +500,6 @@ import matplotlib
 matplotlib.use("Agg")
 import matplotlib.pyplot as plt
 from pysam import VariantFile
-import snakemake
 
 quals = [record.qual for record in VariantFile(snakemake.input[0])]
 plt.hist(quals)

--- a/technology_and_tooling/snakemake/index.md
+++ b/technology_and_tooling/snakemake/index.md
@@ -1,5 +1,5 @@
 ---
-name: "Snakemake Tutorial"
+name: "Snakemake"
 id: snakemake
 dependsOn: [technology_and_tooling.bash_shell]
 files: [setup.md, basics.md, advanced.md, additional_features.md, short.md]
@@ -14,8 +14,7 @@ attribution:
     image: https://raw.githubusercontent.com/snakemake/snakemake/main/snakemake/report/template/logo.svg
     license: MIT license
 summary: |
-  This tutorial introduces the text-based workflow system
-  Snakemake.
+  This course introduces the text-based workflow system Snakemake. Snakemake is a general-purpose workflow management system for any discipline.
 ---
 
 This tutorial introduces the text-based workflow system

--- a/technology_and_tooling/snakemake/setup.md
+++ b/technology_and_tooling/snakemake/setup.md
@@ -18,7 +18,8 @@ attribution:
 
 ## Requirements
 
-To go through this tutorial, you need a number of software packages including
+To go through this tutorial, you need the following software installed (however, don't install any of these manually now as we guide you
+through better ways below):
 [Python](https://www.python.org),
 [Snakemake](https://snakemake.readthedocs.io),
 [BWA](http://bio-bwa.sourceforge.net),
@@ -29,8 +30,6 @@ To go through this tutorial, you need a number of software packages including
 [Jinja2](https://jinja.palletsprojects.com),
 [NetworkX](https://networkx.github.io),
 [Matplotlib](https://matplotlib.org).
-However, don\'t install any of these manually now as we guide you
-through better ways below.
 
 ## Run tutorial for free in the cloud via Gitpod
 
@@ -61,16 +60,16 @@ If you prefer to run the tutorial on your local machine, please follow
 the steps below.
 
 The easiest way to set these prerequisites up, is to use the
-[Mambaforge](https://github.com/conda-forge/miniforge#mambaforge) Python
+[Miniforge](https://github.com/conda-forge/miniforge) Python
 3 distribution
-([Mambaforge](https://github.com/conda-forge/miniforge#mambaforge) is a
+([Miniforge](https://github.com/conda-forge/miniforge) is a
 Conda based distribution like
 [Miniconda](https://conda.pydata.org/miniconda.html), which however uses
 [Mamba](https://github.com/mamba-org/mamba) a fast and more robust
 replacement for the [Conda](https://conda.pydata.org) package manager).
 The tutorial assumes that you are using either Linux or MacOS X. Both
 Snakemake and
-[Mambaforge](https://github.com/conda-forge/miniforge#mambaforge) work
+[Miniforge](https://github.com/conda-forge/miniforge) work
 also under Windows, but the Windows shell is too different to be able to
 provide generic examples.
 
@@ -120,29 +119,29 @@ instructions in this
 [Blogpost](https://blog.osteel.me/posts/2015/01/25/how-to-use-vagrant-on-windows.html).
 Now, you can follow the steps of our tutorial from within your Linux VM.
 
-## Step 1: Installing Mambaforge
+## Step 1: Installing Miniforge
 
 First, please **open a terminal** or make sure you are logged into your
 Vagrant Linux VM. Assuming that you have a 64-bit system, on Linux,
 download and install Miniconda 3 with
 
 ```shell
-curl -L https://github.com/conda-forge/miniforge/releases/latest/download/Mambaforge-Linux-x86_64.sh -o Mambaforge-Linux-x86_64.sh
-bash Mambaforge-Linux-x86_64.sh
+curl -L https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-Linux-x86_64.sh -o Miniforge3-Linux-x86_64.sh
+bash Miniforge3-Linux-x86_64.sh
 ```
 
 On MacOS with x86_64 architecture, download and install with
 
 ```shell
-curl -L https://github.com/conda-forge/miniforge/releases/latest/download/Mambaforge-MacOSX-x86_64.sh -o Mambaforge-MacOSX-x86_64.sh
-bash Mambaforge-MacOSX-x86_64.sh
+curl -L https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-MacOSX-x86_64.sh -o Miniforge3-MacOSX-x86_64.sh
+bash Miniforge3-MacOSX-x86_64.sh
 ```
 
 On MacOS with ARM/M1 architecture, download and install with
 
 ```shell
-curl -L https://github.com/conda-forge/miniforge/releases/latest/download/Mambaforge-MacOSX-arm64.sh -o Mambaforge-MacOSX-arm64.sh
-bash Mambaforge-MacOSX-arm64.sh
+curl -L https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-MacOSX-arm64.sh -o Miniforge3-MacOSX-arm64.sh
+bash Miniforge3-MacOSX-arm64.sh
 ```
 
 When you are asked the question
@@ -194,6 +193,8 @@ working directory.
 
 ## Step 3: Creating an environment with the required software
 
+All interactions with Conda package management below can be conducted with either conda, mamba or micromamba. For the steps in the [advanced](advanced.md) part of the tutorial, you have to install mamba though in case you don’t have it.
+
 First, make sure to activate the conda base environment with
 
 ```shell
@@ -224,7 +225,7 @@ CONDA_SUBDIR=osx-64 mamba env create --name snakemake-tutorial --file environmen
 
 If you don\'t have the [Mamba](https://github.com/mamba-org/mamba)
 command because you used a different conda distribution than
-[Mambaforge](https://github.com/conda-forge/miniforge#mambaforge), you
+[Miniforge](https://github.com/conda-forge/miniforge), you
 can also first install [Mamba](https://github.com/mamba-org/mamba)
 (which is a faster and more robust replacement for
 [Conda](https://conda.pydata.org)) in your base environment with

--- a/technology_and_tooling/snakemake/short.md
+++ b/technology_and_tooling/snakemake/short.md
@@ -288,7 +288,7 @@ notebook.
 
 We open the notebook in the editor and add the following content
 
-```python
+```snakemake
 import pandas as pd
 import altair as alt
 from pysam import VariantFile

--- a/technology_and_tooling/snakemake/short.md
+++ b/technology_and_tooling/snakemake/short.md
@@ -22,7 +22,7 @@ Here we provide a short tutorial that guides you through the main
 features of Snakemake. Note that this is not suited to learn Snakemake
 from scratch, rather to give a first impression. To really learn
 Snakemake (starting from something simple, and extending towards
-[label](../index.md)advanced features), use the main `tutorial`.
+[label](../index.md)advanced features), use the main [tutorial](index).
 
 This document shows all steps performed in the official [Snakemake live
 demo](https://youtu.be/hPrXcUUp70Y), such that it becomes possible to
@@ -32,13 +32,13 @@ bottom of this document.
 The examples presented in this tutorial come from Bioinformatics.
 However, Snakemake is a general-purpose workflow management system for
 any discipline. For an explanation of the steps you will perform here,
-have a look at `tutorial-background`. More
-thorough explanations are provided in the full `tutorial`.
+have a look at [tutorial-background](background). More
+thorough explanations are provided in the full [tutorial](index).
 
 ## Prerequisites
 
 First, install Snakemake via Conda, as outlined in
-`conda-install`. The minimal version of
+[`Installation via Conda/Mamba`](install). The minimal version of
 Snakemake is sufficient for this demo.
 
 Second, download and unpack the test data needed for this example from
@@ -135,16 +135,22 @@ Now, test your workflow by simulating the creation of the file
 `results/mapped/A.bam` via
 
 ```bash
-snakemake --use-conda -n results/mapped/A.bam
+snakemake --software-deployment-method conda -n results/mapped/A.bam
 ```
 
 to perform a dry-run and
 
 ```bash
-snakemake --use-conda results/mapped/A.bam --cores 1
+snakemake --software-deployment-method conda results/mapped/A.bam --cores 1
 ```
 
 to perform the actual execution.
+
+:::callout
+
+The `--software-deployment-method` option has a shorthand alias `--sdm`, which we will use for brevity in the rest of this tutorial. There are two other long-form aliases `--deployment-method` and `--deployment`.
+
+:::
 
 ## Step 3
 
@@ -248,8 +254,9 @@ and output file
 Instead of a shell command, we use Snakemake\'s Jupyter notebook
 integration by specifying
 
-```yaml
-notebook: "notebooks/plot-quals.py"
+```snakemake
+notebook:
+    "notebooks/plot-quals.py/ipynb"
 ```
 
 instead of using the `shell` directive as before.
@@ -273,7 +280,7 @@ dependencies:
 Then, we let Snakemake generate a skeleton notebook for us with
 
 ```shell
-snakemake --draft-notebook results/plots/quals.svg --cores 1 --use-conda
+snakemake --draft-notebook results/plots/quals.svg --cores 1 --sdm conda
 ```
 
 Snakemake will print instructions on how to open, edit and execute the
@@ -285,7 +292,6 @@ We open the notebook in the editor and add the following content
 import pandas as pd
 import altair as alt
 from pysam import VariantFile
-import snakemake
 
 quals = pd.DataFrame({"qual": [record.qual for record in VariantFile(snakemake.input[0])]})
 
@@ -305,7 +311,7 @@ automatically inserts into the notebook before executing the rule.
 Make sure to test your workflow with
 
 ```bash
-snakemake --use-conda --force results/plots/quals.svg --cores 1
+snakemake --sdm conda --force results/plots/quals.svg --cores 1
 ```
 
 Here, the force ensures that the readily drafted notebook is re-executed


### PR DESCRIPTION
Resolves #142 

- [x] Update docs following Snakemake 8 official tutorials
- [x] Make sure fig in 'basics' (above step 6 renders; currently missing)
- [x] Remove mention of 'atom' editor (end-of-life) [basics, step 1]
- [x] remove `import snakemake` from code sample (bug)