### PR TITLE
display python and cpp versions side-by-side

### DIFF
--- a/software_architecture_and_design/procedural/index.md
+++ b/software_architecture_and_design/procedural/index.md
@@ -4,7 +4,7 @@ name: Procedural Programming
 files:
   [
     [variables_cpp.md, functions_cpp.md, containers_cpp.md],
-    [variables_python.md, functions_python.md, containers_python.md, arrays_python.md],
+    [variables_python.md, containers_python.md, functions_python.md, arrays_python.md],
   ]
 dependsOn: [technology_and_tooling.ide]
 summary: |

--- a/software_architecture_and_design/procedural/index.md
+++ b/software_architecture_and_design/procedural/index.md
@@ -4,7 +4,7 @@ name: Procedural Programming
 files:
   [
     [variables_cpp.md, functions_cpp.md, containers_cpp.md],
-    [variables_python.md, containers_python.md, functions_python.md, arrays_python.md],
+    [variables_python.md, functions_python.md, containers_python.md, arrays_python.md],
   ]
 dependsOn: [technology_and_tooling.ide]
 summary: |


### PR DESCRIPTION
Changed index pages of Functional Programming and Object-Oriented Programming to show parallel tracks of python and cpp pages side-by-side rather than interspersed, as was already done at Structural Programming.
