### PR TITLE
Add learning outcomes to essential maths course

### DIFF
--- a/scientific_computing/essential_maths/01_graphs.md
+++ b/scientific_computing/essential_maths/01_graphs.md
@@ -2,6 +2,12 @@
 name: Graphs
 dependsOn: []
 tags: []
+learningOutcomes:
+  - Be able to describe the fundamental components of a graph
+  - Understand how to derive and use the equation of a straight line
+  - Understand how to interpret graphs of polynomial functions
+  - Be able to sketch the graph of a function
+  - Use graphs to understand and evaluate functions
 attribution:
   - citation: This material has been adapted from material by Fergus Cooper and others from the "Essential Mathematics" module at the Doctoral Training Centre, University of Oxford.
     url: https://www.dtc.ox.ac.uk/

--- a/scientific_computing/essential_maths/02_indices_and_logs.md
+++ b/scientific_computing/essential_maths/02_indices_and_logs.md
@@ -2,6 +2,12 @@
 name: Indices, logs and exponentials
 dependsOn: [scientific_computing.essential_maths.01_graphs]
 tags: []
+learningOutcomes:
+  - Understand the meaning of raising a number to an index
+  - Be able to rearrange algebraic expressions with indices
+  - Understand logarithms and their relationship with indices
+  - Be able to apply the laws of logarithms to algebraic expressions
+  - Understand the use of logarithmic axes in graphs
 attribution:
   - citation: This material has been adapted from material by Fergus Cooper and others from the "Essential Mathematics" module at the Doctoral Training Centre, University of Oxford.
     url: https://www.dtc.ox.ac.uk/

--- a/scientific_computing/essential_maths/03_differentiation_1.md
+++ b/scientific_computing/essential_maths/03_differentiation_1.md
@@ -2,6 +2,11 @@
 name: Differentiation 1
 dependsOn: [scientific_computing.essential_maths.02_indices_and_logs]
 tags: []
+learningOutcomes:
+  - Understand the concept of the rate of change of a quantity
+  - Be able to calculate the gradient of a curve at a point
+  - Understand the relationship between the derivative and gradient of a function
+  - Be able to calculate and interpret the derivative of a function
 attribution:
   - citation: This material has been adapted from material by Fergus Cooper and others from the "Essential Mathematics" module at the Doctoral Training Centre, University of Oxford.
     url: https://www.dtc.ox.ac.uk/

--- a/scientific_computing/essential_maths/04_differentiation_2.md
+++ b/scientific_computing/essential_maths/04_differentiation_2.md
@@ -2,6 +2,13 @@
 name: Differentiation 2
 dependsOn: [scientific_computing.essential_maths.03_differentiation_1]
 tags: []
+learningOutcomes:
+  - Be able to recognise the derivatives of standard functions
+  - Understand the associative, commutative and distributive properties of derivatives
+  - Be able to use the chain rule to differentiate a function of a function
+  - Be able to use the product rule for differentiating a product of functions
+  - Be able to use the quotient rule for differentiating the ratio of functions
+  - Be able to use SymPy to calculate derivatives in Python
 attribution:
   - citation: This material has been adapted from material by Fergus Cooper and others from the "Essential Mathematics" module at the Doctoral Training Centre, University of Oxford.
     url: https://www.dtc.ox.ac.uk/

--- a/scientific_computing/essential_maths/05_differentiation_3.md
+++ b/scientific_computing/essential_maths/05_differentiation_3.md
@@ -2,6 +2,10 @@
 name: Differentiation 3
 dependsOn: [scientific_computing.essential_maths.04_differentiation_2]
 tags: []
+learningOutcomes:
+  - Be able to calculate the derivative of exponential and logarithmic functions
+  - Understand how to differentiate functions of multiple independent variables
+  - Be able to calculate higher order derivatives with respect to multiple variables
 attribution:
   - citation: This material has been adapted from material by Fergus Cooper and others from the "Essential Mathematics" module at the Doctoral Training Centre, University of Oxford.
     url: https://www.dtc.ox.ac.uk/

--- a/scientific_computing/essential_maths/06_integration_1.md
+++ b/scientific_computing/essential_maths/06_integration_1.md
@@ -2,6 +2,12 @@
 name: Integration 1
 dependsOn: [scientific_computing.essential_maths.05_differentiation_3]
 tags: []
+learningOutcomes:
+  - Understand the concept of the area under a graph
+  - Be able to calculate the integral of a function
+  - Recognise integration as the inverse operation of differentiation
+  - Be able to use SymPy to integrate functions in Python
+  - Be able to use the substitution method to integrate a function of a function
 attribution:
   - citation: This material has been adapted from material by Fergus Cooper and others from the "Essential Mathematics" module at the Doctoral Training Centre, University of Oxford.
     url: https://www.dtc.ox.ac.uk/

--- a/scientific_computing/essential_maths/07_integration_2.md
+++ b/scientific_computing/essential_maths/07_integration_2.md
@@ -2,6 +2,9 @@
 name: Integration 2
 dependsOn: [scientific_computing.essential_maths.06_integration_1]
 tags: []
+learningOutcomes:
+  - Be able to use integration by parts to integrate a product of functions
+  - Be able to apply the method of partial fractions to integrate fractional functions
 attribution:
   - citation: This material has been adapted from material by Fergus Cooper and others from the "Essential Mathematics" module at the Doctoral Training Centre, University of Oxford.
     url: https://www.dtc.ox.ac.uk/

--- a/scientific_computing/essential_maths/08_complex_numbers.md
+++ b/scientific_computing/essential_maths/08_complex_numbers.md
@@ -2,6 +2,15 @@
 name: Complex numbers
 dependsOn: [scientific_computing.essential_maths.07_integration_2]
 tags: []
+learningOutcomes:
+  - Understand the concept of imaginary numbers
+  - Understand complex numbers as having real and imaginary components
+  - Be able to express complex numbers in the complex plane
+  - Understand the conjugate of a complex number
+  - Understand the modulus of a complex number
+  - Be able to perform algebraic operations on complex numbers
+  - Be able to express comples numbers in polar coordinates
+  - Understand the relationship between complex numbers and trigonometric functions
 attribution:
   - citation: This material has been adapted from material by Fergus Cooper and others from the "Essential Mathematics" module at the Doctoral Training Centre, University of Oxford.
     url: https://www.dtc.ox.ac.uk/

--- a/scientific_computing/essential_maths/09_differential_equations_1.md
+++ b/scientific_computing/essential_maths/09_differential_equations_1.md
@@ -2,6 +2,10 @@
 name: Differential equations 1
 dependsOn: [scientific_computing.essential_maths.07_integration_2]
 tags: []
+learningOutcomes:
+  - Understand the concept of a differential equation
+  - Be able to use integration to solve simple differentiatial equations
+  - Be able to use the method of separation of variables to solve differential equations
 attribution:
   - citation: This material has been adapted from material by Fergus Cooper and others from the "Essential Mathematics" module at the Doctoral Training Centre, University of Oxford.
     url: https://www.dtc.ox.ac.uk/

--- a/scientific_computing/essential_maths/10_differential_equations_2.md
+++ b/scientific_computing/essential_maths/10_differential_equations_2.md
@@ -2,6 +2,9 @@
 name: Differential equations 2
 dependsOn: [scientific_computing.essential_maths.09_differential_equations_1]
 tags: []
+learningOutcomes:
+  - Be able to translate a literal description between quantities into a differential equation
+  - Understand how to use the method of substitution to solve higher-order differential equations
 attribution:
   - citation: This material has been adapted from material by Fergus Cooper and others from the "Essential Mathematics" module at the Doctoral Training Centre, University of Oxford.
     url: https://www.dtc.ox.ac.uk/

--- a/scientific_computing/essential_maths/11_differential_equations_3.md
+++ b/scientific_computing/essential_maths/11_differential_equations_3.md
@@ -2,6 +2,9 @@
 name: Differential equations 3
 dependsOn: [scientific_computing.essential_maths.10_differential_equations_2]
 tags: []
+learningOutcomes:
+  - Be able to find the steady-state solution of a differential equation
+  - Be able to use Euler's method to numerically solve differential equations
 attribution:
   - citation: This material has been adapted from material by Fergus Cooper and others from the "Essential Mathematics" module at the Doctoral Training Centre, University of Oxford.
     url: https://www.dtc.ox.ac.uk/

--- a/scientific_computing/essential_maths/12_linear_algebra_1.md
+++ b/scientific_computing/essential_maths/12_linear_algebra_1.md
@@ -2,6 +2,16 @@
 name: Linear algebra 1
 dependsOn: [scientific_computing.essential_maths.08_complex_numbers]
 tags: []
+learningOutcomes:
+  - Understand the concept of a matrix
+  - Be able to perform addition and subtraction of matrices
+  - Be able to multiply a matrix by a scalar
+  - Understand the associative, commutative and distributive laws of matrices
+  - Be able to find the determinant of a matrix
+  - Be able to invert a matrix
+  - Be able to find the transpose of a matrix
+  - Be able to express a set of simultaneous equations as a matrix equation
+  - Understand how to solve a matrix equation $Ax=b$
 attribution:
   - citation: This material has been adapted from material by Fergus Cooper and others from the "Essential Mathematics" module at the Doctoral Training Centre, University of Oxford.
     url: https://www.dtc.ox.ac.uk/

--- a/scientific_computing/essential_maths/13_linear_algebra_2.md
+++ b/scientific_computing/essential_maths/13_linear_algebra_2.md
@@ -2,6 +2,11 @@
 name: Linear algebra 2
 dependsOn: [scientific_computing.essential_maths.12_linear_algebra_1]
 tags: []
+learningOoutcomes:
+  - Understand the concept of a singular matrix
+  - Understand the concept of the null space for a matrix
+  - Be able to find the eigenvalues and eigenvectors of a matrix equation
+  - Be able to diagonalise a matrix
 attribution:
   - citation: This material has been adapted from material by Fergus Cooper and others from the "Essential Mathematics" module at the Doctoral Training Centre, University of Oxford.
     url: https://www.dtc.ox.ac.uk/

--- a/scientific_computing/essential_maths/14_system_1.md
+++ b/scientific_computing/essential_maths/14_system_1.md
@@ -6,6 +6,11 @@ dependsOn:
     scientific_computing.essential_maths.13_linear_algebra_2,
   ]
 tags: []
+learningOutcomes:
+  - Understand the concept of a linear system of differential equations
+  - Recognise the different methods to solve a linear system
+  - Be able to turn a coupled linear system into a single differential equation
+  - Be able to use matrix diagonalisation to solve a linear system in terms of its eigenvalues
 attribution:
   - citation: This material has been adapted from material by Fergus Cooper and others from the "Essential Mathematics" module at the Doctoral Training Centre, University of Oxford.
     url: https://www.dtc.ox.ac.uk/

--- a/scientific_computing/essential_maths/15_system_2.md
+++ b/scientific_computing/essential_maths/15_system_2.md
@@ -2,6 +2,14 @@
 name: Systems of differential equations 2
 dependsOn: [scientific_computing.essential_maths.14_system_1]
 tags: []
+learningOutcomes:
+  - Be able to analyse non-linear systems in multiple dimensions
+  - Understand how to simplify the form of a system using parameter re-scaling
+  - Understand how to use properties of a system to simplify the set of equations
+  - Understand the concept of a phase plane
+  - Be able to identify nullclines of a non-linear system
+  - Be able to plot the phase plane of a non-linear system
+  - Be able to plot the phase plane of a non-linear system using matplotlib in Python
 attribution:
   - citation: This material has been adapted from material by Fergus Cooper and others from the "Essential Mathematics" module at the Doctoral Training Centre, University of Oxford.
     url: https://www.dtc.ox.ac.uk/

--- a/scientific_computing/essential_maths/16_system_3.md
+++ b/scientific_computing/essential_maths/16_system_3.md
@@ -2,6 +2,9 @@
 name: Systems of differential equations 3
 dependsOn: [scientific_computing.essential_maths.15_system_2]
 tags: []
+learningOutcomes:
+  - Be able to describe the behaviour of a system using eigenvalue analysis
+  - Understand the nature of a system's stability from its eigenvalues
 attribution:
   - citation: This material has been adapted from material by Fergus Cooper and others from the "Essential Mathematics" module at the Doctoral Training Centre, University of Oxford.
     url: https://www.dtc.ox.ac.uk/


### PR DESCRIPTION
This PR adds learning outcomes to all complete (i.e. except for probability) chapters of the Essential Maths course, under the Scientific Computing section.

Closes #165 