### PR TITLE
Add learning outcomes to linear algebra solvers course

### DIFF
--- a/scientific_computing/linear_algebra/01-matrix-form-of-equations.md
+++ b/scientific_computing/linear_algebra/01-matrix-form-of-equations.md
@@ -2,6 +2,12 @@
 name: Matrix form of equations
 dependsOn: []
 tags: []
+learningOutcomes:
+  - Be able to express a set of simultaneous equations as a matrix equation
+  - Understand how the geometry of a system of linear equations determines their solution
+  - Understand the concept of a singular matrix
+  - Be able to find the determinant of a matrix
+  - Be able to find the inverse of a matrix using NumPy in Python
 attribution:
   - citation: This material has been adapted from material by Martin Robinson from the "Scientific Computing" module of the SABS R³ Center for Doctoral Training.
     url: https://www.sabsr3.ox.ac.uk

--- a/scientific_computing/linear_algebra/04-LU-decomposition.md
+++ b/scientific_computing/linear_algebra/04-LU-decomposition.md
@@ -2,6 +2,12 @@
 name: LU decomposition
 dependsOn: ["scientific_computing.linear_algebra.02-gaussian-elimination"]
 tags: []
+learningOutcomes:
+  - Understand the concept of matrix decomposition
+  - Understand the benefits of different matrix decomposition methods
+  - Be able to perform LU decomposition on a matrix
+  - Understand the concept of pivoting in LU decomposition
+  - Recognise the benefit of LDL decomposition for symmetric matrices
 attribution:
   - citation: This material has been adapted from material by Martin Robinson from the "Scientific Computing" module of the SABS R³ Center for Doctoral Training.
     url: https://www.sabsr3.ox.ac.uk

--- a/scientific_computing/linear_algebra/06-Cholesky-decomposition.md
+++ b/scientific_computing/linear_algebra/06-Cholesky-decomposition.md
@@ -2,6 +2,10 @@
 name: Cholesky decomposition
 dependsOn: ["scientific_computing.linear_algebra.04-LU-decomposition"]
 tags: []
+learningOutcomes:
+  - Recognise symmetric positive definite (SPD) matrices as a special case for matrix decomposition
+  - Understand Cholesky decomposition as a method to efficiently decompose SPD matrices
+  - Understand the relationship between LU decomposition and Cholesky decomposition
 attribution:
   - citation: This material has been adapted from material by Martin Robinson from the "Scientific Computing" module of the SABS R³ Center for Doctoral Training.
     url: https://www.sabsr3.ox.ac.uk

--- a/scientific_computing/linear_algebra/07-QR-decomposition.md
+++ b/scientific_computing/linear_algebra/07-QR-decomposition.md
@@ -2,6 +2,9 @@
 name: QR decomposition
 dependsOn: ["scientific_computing.linear_algebra.06-Cholesky-decomposition"]
 tags: []
+learningOutcomes:
+  - Understand how to solve a matrix equation using QR decomposition
+  - Be able to build the QR decomposition matrices using Householder reflections, Givens rotations and the Gram-Schmidt process
 attribution:
   - citation: This material has been adapted from material by Martin Robinson from the "Scientific Computing" module of the SABS R³ Center for Doctoral Training.
     url: https://www.sabsr3.ox.ac.uk

--- a/scientific_computing/linear_algebra/07-QR-decomposition.md
+++ b/scientific_computing/linear_algebra/07-QR-decomposition.md
@@ -4,7 +4,8 @@ dependsOn: ["scientific_computing.linear_algebra.06-Cholesky-decomposition"]
 tags: []
 learningOutcomes:
   - Understand how to solve a matrix equation using QR decomposition
-  - Be able to build the QR decomposition matrices using Householder reflections, Givens rotations and the Gram-Schmidt process
+  - Understand how to build QR decomposition matrices using Householder reflections, Givens rotations and the Gram-Schmidt process
+  - Be able to use a QR decomposition to fit a model to data
 attribution:
   - citation: This material has been adapted from material by Martin Robinson from the "Scientific Computing" module of the SABS R³ Center for Doctoral Training.
     url: https://www.sabsr3.ox.ac.uk


### PR DESCRIPTION
This PR adds learning outcomes to chapters of the Linear Algebra Solvers course under the Scientific Computing section where they were missing.

Closes #169 