### PR TITLE
Add learning outcomes to Intro to PyBaMM course

### DIFF
--- a/libraries/pybamm/01_running_pybamm.md
+++ b/libraries/pybamm/01_running_pybamm.md
@@ -2,6 +2,13 @@
 name: Running PyBaMM
 dependsOn: []
 tags: [pybamm]
+learningOutcomes:
+  - Be able to make the PyBaMM library available in a Python program
+  - Be able to use PyBaMM's built-in lithium-ion battery models
+  - Be able to solve a PyBaMM model over a specified time interval
+  - Be able to generate a plot of the key variables of a PyBaMM simulation
+  - Understand how to query the variables and parameters used in a model
+  - Understand how to query the relevant citations for parts of the PyBaMM library
 attribution:
   - citation: >
       PyBaMM documentation by the PyBaMM Team

--- a/libraries/pybamm/02_experiments.md
+++ b/libraries/pybamm/02_experiments.md
@@ -3,6 +3,9 @@ name: The Experiment class
 id: experiments
 dependsOn: [libraries.pybamm.01_running_pybamm]
 tags: [pybamm]
+learningOutcomes:
+  - Be able to describe sequences of instructions to create complex PyBaMM experiments
+  - Understand how to access the steps of a multi-step experiment from a simulation output
 attribution:
   - citation: >
       PyBaMM documentation by the PyBaMM Team

--- a/libraries/pybamm/03_parameter_values.md
+++ b/libraries/pybamm/03_parameter_values.md
@@ -2,6 +2,10 @@
 name: Parameter sets
 dependsOn: [libraries.pybamm.02_experiments]
 tags: [pybamm]
+learningOutcomes:
+  - Understand how to explore and use PyBaMM's built-in parameter sets
+  - Be able to change values in existing parameter sets
+  - Be able to create and use your own parameter sets
 attribution:
   - citation: >
       PyBaMM documentation by the PyBaMM Team

--- a/libraries/pybamm/04_outputs.md
+++ b/libraries/pybamm/04_outputs.md
@@ -2,6 +2,11 @@
 name: Making the most of PyBaMM outputs
 dependsOn: [libraries.pybamm.03_parameter_values]
 tags: [pybamm]
+learningOutcomes:
+  - Understand the data contained within a PyBaMM solution object
+  - Understand how to explore the solution variables of a PyBaMM simulation
+  - Be able to create plots of solution variables from a simulation
+  - Be able to save solutions to disk for later use
 attribution:
   - citation: >
       PyBaMM documentation by the PyBaMM Team

--- a/libraries/pybamm/05_using_submodels.md
+++ b/libraries/pybamm/05_using_submodels.md
@@ -2,6 +2,10 @@
 name: Using submodels
 dependsOn: [libraries.pybamm.04_outputs]
 tags: [pybamm]
+learningOutcomes:
+  - Understand the modular structure of PyBaMM
+  - Understand how battery models in PyBaMM are composed of submodels
+  - Be able to describe the physical processes built into PyBaMM's submodels
 attribution:
   - citation: >
       PyBaMM documentation by the PyBaMM Team


### PR DESCRIPTION
This PR adds learning outcomes to each chapter of the Intro to PyBaMM course under the Libraries section.

Learning objectives have not been added for the final exercises chapter due to them being open-ended exercises.

Closes #182 