### PR TITLE
fix: update CI course materials

### DIFF
--- a/software_project_management/continuous_integration/code_coverage.md
+++ b/software_project_management/continuous_integration/code_coverage.md
@@ -60,9 +60,10 @@ Go to [https://codecov.io/](https://codecov.io/), and log in with your GitHub ac
 You may need to follow the steps required to grant Codecov access to see your repositories.
 Once you have done that, you should see your repository on the Codecov webpage.
 
-Next to your repository, you should see text like:
-
-> Not yet enabled [setup repo]
+Next to your repository, you should see a 'Configure' button. Click this to set up code coverage:
+1. Make sure 'Using GitHub Actions' is selected.
+1. Select 'Pytest' from the menu of language options.
+1. Select 'Repository token' to generate a secret just for this repository.
 
 You will see a token of the form `CODECOV_TOKEN=XXXXXXXXXX`.
 This token will allow your GitHub Actions workflow to communicate with Codecov.
@@ -169,7 +170,7 @@ You will find the following step helpful:
 
 ```yml
 - name: Upload coverage reports to Codecov
-  uses: codecov/codecov-action@v3
+  uses: codecov/codecov-action@v5
   with:
     token: ${{ secrets.CODECOV_TOKEN }}
     fail_ci_if_error: true
@@ -198,12 +199,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - name: Set up Python 3.10
+      - name: Set up Python 3.11
         uses: actions/setup-python@v3
         with:
-          python-version: "3.10"
+          python-version: "3.11"
 
       - name: Install dependencies
         run: |
@@ -216,7 +217,7 @@ jobs:
           cat coverage.xml
 
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true

--- a/software_project_management/continuous_integration/documentation.md
+++ b/software_project_management/continuous_integration/documentation.md
@@ -114,5 +114,5 @@ This will take you to the website `https://<project_name>.readthedocs.io/en/late
 
 ::::challenge{id="start-documenting" title="Start documenting"}
 
-Read through the [Sphinx documentation](https://www.sphinx-doc.org/en/master/) and start fleshing out the documenation for your repository.
+Read through the [Sphinx documentation](https://www.sphinx-doc.org/en/master/) and start fleshing out the documentation for your repository.
 ::::

--- a/software_project_management/continuous_integration/github_actions.md
+++ b/software_project_management/continuous_integration/github_actions.md
@@ -126,12 +126,12 @@ The name of this workflow is `Python versions`. It runs whenever there's a push 
 This workflow only has one job, named `build`, and it runs on the latest version of Ubuntu.
 
 This job utilizes a strategy called a matrix, which allows you to run the same job with different configurations.
-In this case, it's set to run the job with three different Python versions - "3.8", "3.9", and "3.10".
+In this case, it's set to run the job with three different Python versions - "3.9", "3.10", and "3.11".
 The `fail-fast` option is set to `false`, which means that if one version fails, the other versions will continue to run.
 
 This job consists of a series of steps:
 
-1. **Checkout Code:** The first step uses an action, `actions/checkout@v3`, which checks out your repository's code onto the runner, so the job can access it.
+1. **Checkout Code:** The first step uses an action, `actions/checkout@v4`, which checks out your repository's code onto the runner, so the job can access it.
 
 2. **Set Up Python:** The next step uses another action, `actions/setup-python@v3`, to set up a Python environment with the version specified in the matrix.
 
@@ -198,11 +198,11 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
 
     steps:
-      - uses: actions/checkout@v3
-      - name: Set up Python 3.10
+      - uses: actions/checkout@v4
+      - name: Set up Python 3.11
         uses: actions/setup-python@v3
         with:
-          python-version: "3.10"
+          python-version: "3.11"
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip setuptools wheel


### PR DESCRIPTION
- bump outdated GitHub Actions versions.
- update the Codecov instructions for their new web interface.