### PR TITLE
fix: update setup_python action in CI course materials

### DIFF
--- a/software_project_management/continuous_integration/code_coverage.md
+++ b/software_project_management/continuous_integration/code_coverage.md
@@ -203,7 +203,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Set up Python 3.11
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
           python-version: "3.11"
 

--- a/software_project_management/continuous_integration/github_actions.md
+++ b/software_project_management/continuous_integration/github_actions.md
@@ -200,7 +200,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python 3.11
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
           python-version: "3.11"
       - name: Install dependencies


### PR DESCRIPTION
I missed this when I updated the other GH Actions.