### PR TITLE
Add missing learning outcomes to Testing course

### DIFF
--- a/technology_and_tooling/testing/mocking.md
+++ b/technology_and_tooling/testing/mocking.md
@@ -3,6 +3,10 @@ name: Using Mocks in Tests
 id: mocking
 dependsOn: [technology_and_tooling.testing.testable_code_fixtures]
 tags: [pytest]
+learningOutcomes:
+  - Understand the use cases for mocking objects when writing tests.
+  - Be able to use `unittest`'s `Mock` class for creating mock objects.
+  - Understand how to patch functionality of objects within a desired scope.
 attribution:
   - citation: This course material was developed as part of UNIVERSE-HPC, which is funded through the SPF ExCALIBUR programme under grant number EP/W035731/1
     url: https://www.universe-hpc.ac.uk

--- a/technology_and_tooling/testing/testable_code_fixtures.md
+++ b/technology_and_tooling/testing/testable_code_fixtures.md
@@ -3,6 +3,12 @@ name: Testable Code and Fixtures
 id: testable_code_fixtures
 dependsOn: [technology_and_tooling.testing.diagnosing_issues]
 tags: [pytest]
+learningOutcomes:
+  - Understand how to design and write testable code.
+  - Understand how grouping tests into classes allows re-use of objects.
+  - Be aware of `pytest`'s built-in methods for setup and teardown of objects in tests.
+  - Understand the benefit and use of fixtures in test suites.
+  - Be able to define fixtures for use in `pytest` test suites.
 attribution:
   - citation: This course material was developed as part of UNIVERSE-HPC, which is funded through the SPF ExCALIBUR programme under grant number EP/W035731/1
     url: https://www.universe-hpc.ac.uk


### PR DESCRIPTION
This PR adds learning outcomes to the Testable Code and Fixtures and Using Mocks in Tests chapters of the Testing course, under Technology and Tooling

Closes #205 