### PR TITLE
Change callout parentheses to braces

### DIFF
--- a/high_performance_computing/parallel_computers/02_connecting.md
+++ b/high_performance_computing/parallel_computers/02_connecting.md
@@ -166,7 +166,7 @@ _ARCHER’s cooling towers © Mike Brown_
 
 Finally, Wee ARCHIE makes its appearance again! This video uses Wee ARCHIE to explain the parallel computer architecture concepts we've introduced.
 
-:::callout(variant="discussion")
+:::callout{variant="discussion"}
 It is worth emphasising that the physical distance between the nodes does impact their communication time i.e. the further apart they are the longer it takes to send a message between them. Can you think of any reason why this behaviour may be problematic on large machines and any possible workarounds?
 
 As usual, share your thought with your fellow learners!

--- a/high_performance_computing/parallel_computers/03_comparison.md
+++ b/high_performance_computing/parallel_computers/03_comparison.md
@@ -100,7 +100,7 @@ Shared-memory systems are difficult to build but easy to use, and are ideal for 
 Distributed-memory systems are easier to build but harder to use, comprising many shared-memory computers each with their own operating system and their own separate memory.
 However, this is the only feasible architecture for constructing a modern supercomputer.
 
-:::callout(variant="discussion")
+:::callout{variant="discussion"}
 These are the two architectures used today. Do you think there is any alternative? Will we keep using them for evermore?
 :::
 

--- a/software_architecture_and_design/functional/higher_order_functions_python.md
+++ b/software_architecture_and_design/functional/higher_order_functions_python.md
@@ -54,7 +54,7 @@ print(add_one(1))
 2
 ```
 
-::::callout(variant="info")
+::::callout{variant="info"}
 The `# NOQA E731` comment is a [flake8](https://pypi.org/project/flake8/) directive to ignore the E731 error, which is raised when a lambda function is assigned to a variable.
 
 Most style guides, which you can learn about in the course on [software testing](/technology_and_tooling/testing), consider it bad style to assign a lambda to a variable as the purpose of a lambda is to avoid having to name the function.

--- a/technology_and_tooling/version_control/04-changes.md
+++ b/technology_and_tooling/version_control/04-changes.md
@@ -172,7 +172,7 @@ The listing for each revision includes
 - **when** it was created,
 - the **log message** Git was given when the revision was committed.
 
-:::callout(variant="tip")
+:::callout{variant="tip"}
 
 ## Compatibility Notice
 

--- a/technology_and_tooling/version_control/09-practice.md
+++ b/technology_and_tooling/version_control/09-practice.md
@@ -27,7 +27,7 @@ You will likely find on the first commit that many files that don't need to be i
 For example, say one of your scripts always generates a file in `out/log.txt`, then you
 could add `out/` to a new .gitignore.
 
-:::callout(variant="tip")
+:::callout{variant="tip"}
 If you are a Windows user and have followed this workshop using Windows Subsystem for
 Linux (WSL) as suggested, then bear in mind that the WSL is a sandboxed environment;
 today we have set up `git config` and SSH for Ubuntu running in WSL but not for your


### PR DESCRIPTION
This PR fixes the incorrect rendering of callouts which used parentheses instead of braces.