### PR TITLE
Move setup instruction in the Docker material from the bottom to the top

### DIFF
--- a/technology_and_tooling/docker/index.md
+++ b/technology_and_tooling/docker/index.md
@@ -5,6 +5,7 @@ dependsOn: [technology_and_tooling.bash_shell]
 files:
   [
     introduction.md,
+    setup.md,
     meet-docker.md,
     managing-containers.md,
     running-containers.md,
@@ -15,7 +16,6 @@ files:
     e01-github-actions.md,
     e02-jekyll-lesson-example.md,
     reproducibility.md,
-    setup.md,
   ]
 learningOutcomes:
   - Learn what containers are.


### PR DESCRIPTION
This PR moves the setup instruction for Docker to the top of the table of content, so the participants do not need to scroll down to find the setup which should be done at the beginning of the course.