### PR TITLE
Add chatbot_development course to technology_and_tooling

### DIFF
--- a/technology_and_tooling/chatbot_development/index.md
+++ b/technology_and_tooling/chatbot_development/index.md
@@ -1,0 +1,138 @@
+---
+name: Chatbot Development
+id: chatbot_development
+dependsOn: []
+files:
+  [
+    m1-01-introduction-to-modern-chatbots.md,
+    m1-02-llm-fundamentals.md,
+    m1-03-api-integration-basics.md,
+    m1-04-building-stateless-and-stateful-chatbots.md,
+    m2-01-the-rag-paradigm.md,
+    m2-02-vector-embeddings.md,
+    m2-03-document-processing-and-chunking.md,
+    m2-04-vector-databases.md,
+    m2-05-building-a-rag-chatbot.md,
+    m3-01-agentic-rag.md,
+    m3-02-reranking-and-hybrid-search.md,
+    m3-03-knowledge-graphs.md,
+    m3-04-semantic-caching.md,
+    m3-05-evaluating-and-optimising-retrieval.md,
+    m4-01-conversation-history-management.md,
+    m4-02-conversation-summarisation.md,
+    m4-03-selective-memory.md,
+    m4-04-retrieval-based-memory.md,
+    m4-05-user-personalisation.md,
+    m5-01-backend-design-with-fastapi.md,
+    m5-02-frontend-integration.md,
+    m5-03-docker-containerisation.md,
+    m5-04-cloud-deployment.md,
+    m5-05-authentication-and-security.md,
+    m6-01-user-engagement-metrics.md,
+    m6-02-conversation-analytics.md,
+    m6-03-performance-monitoring.md,
+    m6-04-logging-and-observability.md,
+    m6-05-ab-testing-and-experimentation.md,
+    m7-01-production-prompt-engineering.md,
+    m7-02-safety-and-content-moderation.md,
+    m7-03-cost-optimisation.md,
+    m7-04-scaling-strategies.md,
+    m7-05-alternative-llm-providers.md,
+    m8-01-capstone-project-brief.md,
+    m8-02-deliverables-and-documentation.md,
+  ]
+learningOutcomes:
+  - Integrate an LLM (OpenAI) into a chatbot with stateful conversation and token-budget management.
+  - Build a Retrieval-Augmented Generation pipeline over a ChromaDB vector store with source citation.
+  - Apply advanced retrieval techniques including query expansion, re-ranking, hybrid search, knowledge graphs, and semantic caching.
+  - Manage conversation context with windowing, rolling summarisation, selective memory, and retrieval-based memory.
+  - Deliver a domain-specific Streamlit chatbot capstone, evaluated with retrieval and response-quality metrics.
+attribution:
+  - citation: >
+      Oxford AI Competency Centre (2026). Chatbot Development Course.
+    url: https://github.com/OxfordCompetencyCenters/aicc_chatbot_modules
+    license: CC-BY-4.0
+summary: |
+  Hands-on training in building production-ready chatbots using Large Language Models (LLMs).
+  Participants progress from fundamental concepts through Retrieval-Augmented Generation (RAG),
+  memory management, and advanced retrieval techniques, finishing with a Streamlit-based capstone
+  project. Three optional modules cover deployment, analytics, and production hardening.
+---
+
+# Chatbot Development Course
+
+Hands-on training in building production-ready chatbots using Large Language Models (LLMs). Participants progress from fundamental concepts through advanced techniques including Retrieval-Augmented Generation (RAG), memory management, and advanced retrieval, culminating in a local Streamlit chatbot as the capstone.
+
+**Duration:** 10 hours of core content (four core modules of 2.5 hours each) delivered as four half-day sessions on non-consecutive weeks. Three optional modules (deployment, analytics, production hardening) are self-paced.
+**Level:** Intermediate
+**Target audience:** Software engineers with no prior AI experience.
+
+## Prerequisites
+
+### Required technical skills
+
+- **Python programming:** intermediate proficiency including classes, functions, error handling, and working with APIs.
+- **Command line:** comfortable with terminal / shell operations, environment variables, and package management (pip).
+- **Git & version control:** basic understanding of repositories, cloning, and commits.
+- **JSON & REST APIs:** experience making HTTP requests and parsing JSON responses.
+
+### Recommended background
+
+- Basic understanding of machine learning concepts (helpful but not required).
+- Familiarity with natural language processing terminology.
+- Prior exposure to any API / backend framework (Flask, FastAPI, Django).
+
+## Pre-course setup
+
+Participants complete this once before the first session. The goal is that `00-environment-check.ipynb` in the companion repo runs top to bottom with every cell printing `OK:`.
+
+1. Install Python 3.10+ and verify: `python --version`.
+2. Clone the companion repository that holds the runnable notebooks and the Streamlit capstone:
+   ```
+   git clone https://github.com/OxfordCompetencyCenters/aicc_chatbot_modules.git
+   cd aicc_chatbot_modules
+   ```
+3. Create and activate a virtual environment:
+   ```
+   python -m venv .venv
+   source .venv/bin/activate          # macOS / Linux
+   .venv\Scripts\activate             # Windows PowerShell
+   ```
+4. Install the pinned dependencies:
+   ```
+   pip install -r requirements.txt
+   ```
+5. Register for an OpenAI API key via [Oxford API access](https://oerc.ox.ac.uk/ai-centre/generative-ai-tools/api-access).
+6. Copy the example env file and paste your key:
+   ```
+   cp .env.example .env
+   # edit .env and replace sk-replace-me with your actual key
+   ```
+7. Run the environment check:
+   ```
+   jupyter lab 00-environment-check.ipynb
+   ```
+   Execute every cell. If they all print `OK:`, you are ready for Module 1.
+
+## Module overview
+
+### Core modules (taught, four half-day sessions)
+
+- **Module 1 — Chatbot Foundations & API Integration.** Evolution from rule-based to LLM-powered chatbots. LLM fundamentals (tokens, context windows, sampling parameters). OpenAI API integration. Stateless vs stateful chatbot design. System prompts and conversation management.
+- **Module 2 — RAG: Vector Embeddings & Semantic Search.** Retrieval-Augmented Generation paradigm. Vector embeddings and semantic similarity. Document chunking strategies. Vector databases (ChromaDB). Building an end-to-end RAG chatbot with source citations.
+- **Module 3 — Advanced RAG & Knowledge Graph Integration.** Agentic RAG with query expansion and decomposition. Re-ranking and hybrid search. Knowledge graphs for structured reasoning. Semantic caching for cost reduction. Retrieval quality metrics and evaluation.
+- **Module 4 — Memory & Context Management.** Short-term vs long-term memory architectures. Conversation window management. Summarisation. Selective memory and importance scoring. Retrieval-based memory and cross-session recall. User profile building and personalisation.
+
+### Optional modules (self-paced)
+
+- **Module 5 — Deployment Architecture.** RESTful API design with FastAPI. Frontend development (Streamlit, React). Docker containerisation. Cloud deployment. Authentication and security. (A separate OxRSE course covers Docker in detail — participants are encouraged to take that alongside.)
+- **Module 6 — Chatbot Analytics & Observability.** User engagement metrics. Conversation quality analytics. Performance monitoring. Structured logging and tracing. A/B testing.
+- **Module 7 — Production Best Practices.** Production prompt engineering. Content moderation and safety. Cost optimisation. Scaling. Alternative LLM providers.
+
+### Capstone
+
+- **Module 8 — Capstone Project Integration.** Build a domain-specific chatbot that combines RAG over a ChromaDB vector store with conversation memory and auto-summarisation. The deliverable is a local Streamlit application launched with `streamlit run app.py`. Experiments evaluate retrieval quality and response quality; results are reported in a structured format alongside a reflection and documentation (README + Architecture Decision Records).
+
+## Companion repository
+
+Runnable notebooks (one per section), a pinned Python environment, a Streamlit capstone scaffold, and the `00-environment-check.ipynb` smoke test live in the companion repo: [OxfordCompetencyCenters/aicc_chatbot_modules](https://github.com/OxfordCompetencyCenters/aicc_chatbot_modules). Each lesson in this course ends with a "Hands-on practical" link that points to the matching notebook.

--- a/technology_and_tooling/chatbot_development/index.md
+++ b/technology_and_tooling/chatbot_development/index.md
@@ -51,6 +51,7 @@ attribution:
   - citation: >
       Oxford AI Competency Centre (2026). Chatbot Development Course.
     url: https://github.com/OxfordCompetencyCenters/aicc_chatbot_modules
+    image: https://github.com/OxfordCompetencyCenters.png
     license: CC-BY-4.0
 summary: |
   Hands-on training in building production-ready chatbots using Large Language Models (LLMs).

--- a/technology_and_tooling/chatbot_development/m1-01-introduction-to-modern-chatbots.md
+++ b/technology_and_tooling/chatbot_development/m1-01-introduction-to-modern-chatbots.md
@@ -1,0 +1,89 @@
+---
+name: Introduction to Modern Chatbots
+dependsOn: []
+tags: [chatbots]
+learningOutcomes:
+  - Understand the evolution from rule-based to LLM-powered chatbots.
+  - Describe modern chatbot architecture and its key components.
+  - Distinguish between stateless and stateful chatbot systems.
+  - Identify real-world chatbot applications and their requirements.
+attribution:
+  - citation: >
+      Oxford AI Competency Centre (2026). Chatbot Development Course.
+    url: https://github.com/OxfordCompetencyCenters/aicc_chatbot_modules
+    license: CC-BY-4.0
+---
+
+Chatbots have been around for decades, but the ones we build today are fundamentally different from their predecessors. In this section we trace that evolution, look at the architecture of a modern chatbot, and introduce a distinction — stateless vs stateful — that will shape every design decision you make throughout this course.
+
+## The Evolution: From ELIZA to ChatGPT
+
+The history of chatbots falls into three broad eras, each defined by a different approach to understanding and generating language.
+
+In the 1960s through the 1990s, chatbots were **rule-based systems**. The most famous example is ELIZA, created at MIT in 1966. ELIZA worked by scanning user input for keywords and applying pattern-matching rules. If you typed "I'm sad," it might respond "Why are you sad?" — not because it understood sadness, but because it had a rule that transformed "I'm [X]" into "Why are you [X]?" Other systems like ALICE refined this approach, but the fundamental limitation remained: an engineer had to anticipate every possible user input and write a rule for it. Anything outside the rules produced nonsensical or generic responses.
+
+From the 2000s through the 2010s, chatbots shifted to **statistical methods**. Instead of hand-written rules, these systems used machine learning to classify user intent ("Is this person asking about shipping or returns?") and extract named entities ("They mentioned order #12345"). This was a significant improvement — the system could generalize from training examples rather than requiring exhaustive rules — but it still required substantial labelled data, and the responses were typically selected from a predefined set rather than generated on the fly.
+
+The 2020s brought **Large Language Models** (LLMs), and with them a paradigm shift. Models like GPT and Claude are trained on billions of text examples and learn deep statistical patterns in language. They don't just classify intent — they understand context, handle nuance, and generate entirely novel responses. A rule-based system could never hold a coherent multi-turn conversation about debugging your Python code. An LLM can, because it has learned the patterns of how such conversations work from vast amounts of text.
+
+This isn't just an incremental improvement. It changes what's possible. Instead of building chatbots that handle a narrow set of predefined scenarios, we can now build systems that engage in open-ended, natural conversation. The rest of this course focuses on how to do that well.
+
+## Modern Chatbot Architecture
+
+It's tempting to think of a chatbot as a simple pipeline: take user input, send it to an LLM, return the response. In practice, production chatbots are more complex. Here is a simplified view of the data flow:
+
+```
+User Input
+    ↓
+[Preprocessing & Intent Detection]
+    ↓
+[Context Management] ← [Conversation History]
+    ↓
+[LLM Processing]
+    ↓
+[Response Generation]
+    ↓
+[Post-processing & Safety]
+    ↓
+User Output
+```
+
+Each layer serves a purpose. The **frontend** is whatever interface the user interacts with — a web chat widget, a mobile app, a Slack integration, or a voice assistant. The **backend** sits behind that interface and handles the business logic: routing requests, managing sessions, enforcing access control, and calling the LLM.
+
+The **LLM layer** is where text generation happens, but it doesn't operate in isolation. A **context management** component assembles the right information to send alongside the user's message — this includes the conversation history, the system prompt that defines the chatbot's behaviour, and potentially retrieved documents (which we'll cover in Module 2 when we discuss Retrieval-Augmented Generation).
+
+Finally, **post-processing and safety** layers check the generated response before it reaches the user. This might involve filtering harmful content, enforcing response length limits, or formatting the output for the target platform.
+
+The **storage layer** ties everything together, persisting conversation histories, user preferences, and analytics data. As you progress through this course, you'll build out each of these components. For now, the key takeaway is that a production chatbot is a system, not just an API call.
+
+## Stateless vs Stateful: A Critical Distinction
+
+One of the most important architectural decisions you'll make is whether your chatbot is stateless or stateful.
+
+A **stateless** chatbot treats every message as an independent request. When a user asks "What is Python?", the bot answers. When the same user then asks "Can you show me an example?", the bot has no idea what "an example" refers to — it has no memory of the previous exchange. Each request arrives in isolation, is processed, and is forgotten. This is simple to implement and cheap to run, because you only send a single user message (plus a system prompt) to the LLM on every call.
+
+A **stateful** chatbot maintains a conversation history. It remembers that the user just asked about Python, so when they say "Can you show me an example?", it understands the context and provides a Python example. This is essential for any interaction that involves follow-up questions, multi-step problem solving, or building on prior context — which is to say, most real conversations.
+
+:::callout
+The trade-off is cost and complexity. A stateful chatbot must store the conversation history and include it in every API call. As the conversation grows, so does the number of tokens sent to the LLM, which means higher latency and higher cost. Managing this growth — pruning old messages, summarising context, staying within the model's context window — is a core challenge we'll address throughout the course, particularly in Module 4.
+:::
+
+For simple, one-shot use cases like answering frequently asked questions ("What are your hours?", "Where are you located?"), a stateless design is perfectly adequate. For anything resembling a real conversation — customer support, tutoring, sales assistance, technical troubleshooting — you need statefulness.
+
+## Real-World Chatbot Applications
+
+To make these concepts concrete, consider how chatbots are used in production today.
+
+**Customer support** is one of the most common applications. A support chatbot needs to be stateful because resolving a problem typically takes multiple turns. The user describes an issue, the bot asks clarifying questions, suggests a solution, and checks whether it worked. The bot also needs to know when to escalate to a human agent — a judgement call that depends on the full conversation context, not just the latest message.
+
+**Internal knowledge bases** combine statefulness with retrieval. When a new employee asks "How do I set up my development environment?", the bot needs to retrieve the relevant documentation and walk them through it step by step. If they ask a follow-up question like "What if I'm on Windows?", the bot must remember what it was explaining and adjust. This pattern — stateful conversation plus document retrieval (RAG) — is one of the most powerful and practical architectures, and we'll build it in Module 2.
+
+**E-commerce assistants** help shoppers find products. A user might say "I'm looking for running shoes," and the bot asks about their budget, preferred brands, and running style. Over several turns, it narrows down recommendations. Without conversation state, the bot would forget the user's budget the moment they mention a brand preference.
+
+**Educational tutors** are particularly interesting because the system prompt can fundamentally change the chatbot's behaviour. A good tutoring bot doesn't just answer questions — it guides students to discover answers themselves through Socratic questioning. It remembers what the student has already tried, celebrates progress, and adjusts its approach based on the student's level of understanding. This requires both statefulness and a carefully crafted system prompt.
+
+Notice the pattern: nearly every production chatbot requires statefulness. Pure stateless bots are the exception, not the rule. This is why we'll spend significant time on conversation management, token budgeting, and memory strategies throughout this course.
+
+## Hands-on practical
+
+Work through the accompanying notebook: [`module_1/01-introduction-to-modern-chatbots.ipynb`](https://github.com/OxfordCompetencyCenters/aicc_chatbot_modules/blob/main/module_1/01-introduction-to-modern-chatbots.ipynb). It runs a tiny ELIZA-style rule-based responder alongside an LLM call on the same inputs so you can see the difference first-hand.

--- a/technology_and_tooling/chatbot_development/m1-01-introduction-to-modern-chatbots.md
+++ b/technology_and_tooling/chatbot_development/m1-01-introduction-to-modern-chatbots.md
@@ -11,6 +11,7 @@ attribution:
   - citation: >
       Oxford AI Competency Centre (2026). Chatbot Development Course.
     url: https://github.com/OxfordCompetencyCenters/aicc_chatbot_modules
+    image: https://github.com/OxfordCompetencyCenters.png
     license: CC-BY-4.0
 ---
 

--- a/technology_and_tooling/chatbot_development/m1-02-llm-fundamentals.md
+++ b/technology_and_tooling/chatbot_development/m1-02-llm-fundamentals.md
@@ -1,0 +1,100 @@
+---
+name: LLM Fundamentals
+dependsOn:
+  - technology_and_tooling.chatbot_development.m1-01-introduction-to-modern-chatbots
+tags: [chatbots, llm]
+learningOutcomes:
+  - Explain how Large Language Models work at a conceptual level.
+  - Understand what tokens are and why they matter for cost and performance.
+  - Describe context windows and their limitations.
+  - Use sampling parameters like temperature and top-p to control LLM output.
+attribution:
+  - citation: >
+      Oxford AI Competency Centre (2026). Chatbot Development Course.
+    url: https://github.com/OxfordCompetencyCenters/aicc_chatbot_modules
+    license: CC-BY-4.0
+---
+
+Before we start writing code, we need to understand what's happening under the hood when we call an LLM API. You don't need to become a machine learning researcher, but a working understanding of these concepts — tokens, context windows, and sampling parameters — is essential for building chatbots that work reliably and cost-effectively.
+
+## How Large Language Models Work
+
+A Large Language Model is a neural network that has been trained on an enormous corpus of text — books, websites, code repositories, conversations, and much more. Through this training, it learns statistical patterns in language: which words tend to follow which other words, how sentences are structured, how ideas relate to one another, and how different styles of writing work.
+
+At its core, an LLM is a **next-token prediction engine**. Given a sequence of text, it predicts what token is most likely to come next. When you type "The capital of France is", the model has seen this pattern so many times during training that it assigns a very high probability to the token "Paris". This prediction mechanism, applied iteratively — predict a token, append it, predict the next one — is what produces the fluent, coherent text that makes LLMs so useful.
+
+The training process happens in stages. First, during **pre-training**, the model learns from billions of text examples in an unsupervised fashion. It develops a broad understanding of language, facts, reasoning patterns, and even some degree of common sense. Next, during **fine-tuning**, the model is trained on more specific data to improve its performance on particular tasks, such as following instructions or holding conversations. Finally, **Reinforcement Learning from Human Feedback (RLHF)** aligns the model's behaviour with human preferences — teaching it to be helpful, harmless, and honest.
+
+It's important to understand what LLMs are *not*. They don't "understand" language the way humans do. They don't have beliefs, intentions, or experiences. They are extraordinarily sophisticated pattern-matching machines. This distinction matters in practice because it explains both their strengths — they can generate fluent text on virtually any topic, adapt to different styles and contexts, and follow complex instructions — and their weaknesses. They can "hallucinate" plausible-sounding but entirely incorrect information, because they're generating text that *looks right* based on patterns, not verifying facts against a reliable source. They have no knowledge of events after their training cutoff. And they can be confidently wrong in ways that are hard to detect without domain expertise.
+
+Understanding these properties will help you build chatbots that leverage LLM strengths while mitigating their weaknesses — through techniques like Retrieval-Augmented Generation (Module 2), careful prompt engineering, and appropriate guardrails.
+
+## Understanding Tokens
+
+Tokens are the fundamental unit of text that LLMs process. A token is not exactly a word — it's a chunk of text determined by the model's tokenizer. In English, one token is roughly four characters, or about three-quarters of a word on average.
+
+Here are some examples of how text gets split into tokens:
+
+```
+"Hello, world!" → ["Hello", ",", " world", "!"] = 4 tokens
+"Chatbot development" → ["Chat", "bot", " development"] = 3 tokens
+"AI" → ["AI"] = 1 token
+```
+
+Notice that punctuation, spaces, and common word fragments all become separate tokens. Short, common words often map to a single token, while longer or rarer words get split into multiple tokens.
+
+Tokens matter for three practical reasons. First, **cost**: LLM APIs charge per token, both for the tokens you send (input/prompt tokens) and the tokens the model generates (output/completion tokens). Every message in your conversation history, every word of your system prompt, and every word of the model's response contributes to your bill. Second, **context limits**: every model has a maximum number of tokens it can process in a single request, called the context window. If your conversation history plus your new message plus the system prompt exceeds this limit, something has to be dropped. Third, **latency**: more tokens means more processing time, which means slower responses for your users.
+
+When you're building a chatbot, you'll need to think about tokens constantly. How many tokens does your system prompt consume? How quickly does your conversation history grow? At what point do you need to start pruning old messages? These are questions we'll address throughout the course, with practical solutions in Module 4.
+
+## Context Windows
+
+The context window is the total number of tokens an LLM can process in a single request. Think of it as the model's working memory — everything it can "see" at once. This includes the system prompt, the full conversation history, the user's latest message, and the space reserved for the model's response.
+
+Different models have different context window sizes:
+
+| Model | Context Window | Approximate Words |
+|-------|----------------|-------------------|
+| GPT-3.5-turbo | 16K tokens | ~12,000 words |
+| GPT-4 | 8K – 128K | Variable by version |
+| GPT-4-turbo | 128K tokens | ~96,000 words |
+| Claude 3 | 200K tokens | ~150,000 words |
+
+These numbers might seem large, but they fill up faster than you'd expect. A detailed system prompt might use 500 tokens. Each conversational turn (user message plus assistant response) might average 200–400 tokens. After 20–30 turns of conversation with a 16K-token model, you're approaching the limit — and that's without including any retrieved documents or other context.
+
+When a conversation exceeds the context window, you have to make choices. The simplest approach is to drop the oldest messages, but this means the bot loses memory of the early parts of the conversation. More sophisticated approaches include summarizing older messages into a compact form, or selectively retaining only the most important parts of the history. We'll implement these strategies in Module 4.
+
+Beyond context windows, LLMs have other important limitations to keep in mind. They have no knowledge of events that occurred after their training data cutoff. They cannot access the internet or external databases on their own. And they can hallucinate — generating text that sounds authoritative but is factually incorrect. Each of these limitations has a corresponding solution that we'll cover later in the course: Retrieval-Augmented Generation (Module 2) grounds responses in real documents, memory management (Module 4) handles efficient context usage, and function calling (Module 7) lets the chatbot access external data sources.
+
+## Sampling Parameters
+
+When an LLM generates a response, it doesn't simply output the single most likely next token. Instead, it produces a probability distribution over all possible next tokens, and then *samples* from that distribution. Sampling parameters let you control how that sampling works, which in turn controls the style, creativity, and consistency of the output.
+
+The most important parameter is **temperature**, which ranges from 0.0 to 2.0. At temperature 0.0, the model always picks the highest-probability token — this produces deterministic, focused, and repetitive output. As you increase the temperature, the model becomes more willing to select lower-probability tokens, producing more varied and creative output. At temperature 2.0, the output becomes quite random and often incoherent.
+
+In practice, the right temperature depends on your use case. For a customer support chatbot, you want consistent, reliable answers — set temperature to 0.0–0.3. For a general-purpose conversational assistant, 0.7–1.0 works well. For brainstorming or creative writing, you might go as high as 1.5. You'll often use different temperature settings for different parts of the same system — for example, low temperature when generating a search query for document retrieval, and a moderate temperature when composing the final user-facing response.
+
+**Top-P** (also called nucleus sampling) is another way to control randomness. Instead of adjusting the probability distribution like temperature does, top-p sets a cumulative probability threshold. If you set top-p to 0.9, the model only considers the smallest set of tokens whose combined probability is at least 90%, and samples from that set. Generally, you adjust either temperature or top-p, not both at once.
+
+Two other useful parameters are **frequency penalty** and **presence penalty**. Frequency penalty reduces the likelihood of tokens that have already appeared in the output, proportional to how many times they've appeared. This helps reduce repetitive phrasing. Presence penalty applies a flat reduction to any token that has appeared at all, encouraging the model to bring up new topics rather than rehashing the same ones.
+
+Finally, **max_tokens** sets a hard limit on the length of the model's response. This is important in production to prevent unexpectedly long (and expensive) responses. If the model hits the max_tokens limit before finishing its thought, the response will be cut off mid-sentence — the `finish_reason` field in the API response will be `"length"` rather than `"stop"`, which you can check and handle in your code.
+
+Here's how these parameters look in an API call:
+
+```python
+response = openai.ChatCompletion.create(
+    model="gpt-3.5-turbo",
+    messages=messages,
+    temperature=0.7,
+    max_tokens=150,
+    top_p=0.9,
+    frequency_penalty=0.5
+)
+```
+
+As you build chatbots throughout this course, you'll develop an intuition for how these parameters affect output quality. The key is to experiment: try different settings, compare the results, and choose values that match the behaviour you want for your specific application.
+
+## Hands-on practical
+
+Work through the accompanying notebook: [`module_1/02-llm-fundamentals.ipynb`](https://github.com/OxfordCompetencyCenters/aicc_chatbot_modules/blob/main/module_1/02-llm-fundamentals.ipynb). It walks through token-counting with `tiktoken`, a context-window budgeting calculation, temperature comparisons, and the `finish_reason == "length"` truncation case.

--- a/technology_and_tooling/chatbot_development/m1-02-llm-fundamentals.md
+++ b/technology_and_tooling/chatbot_development/m1-02-llm-fundamentals.md
@@ -12,6 +12,7 @@ attribution:
   - citation: >
       Oxford AI Competency Centre (2026). Chatbot Development Course.
     url: https://github.com/OxfordCompetencyCenters/aicc_chatbot_modules
+    image: https://github.com/OxfordCompetencyCenters.png
     license: CC-BY-4.0
 ---
 

--- a/technology_and_tooling/chatbot_development/m1-03-api-integration-basics.md
+++ b/technology_and_tooling/chatbot_development/m1-03-api-integration-basics.md
@@ -1,7 +1,7 @@
 ---
 name: API Integration Basics
 dependsOn:
-  - technology_and_tooling.chatbot_development.m1-02-llm-fundamentals
+  - technology_and_tooling.chatbot_development.m1-01-introduction-to-modern-chatbots
 tags: [chatbots, python, api]
 learningOutcomes:
   - Set up OpenAI API credentials securely.

--- a/technology_and_tooling/chatbot_development/m1-03-api-integration-basics.md
+++ b/technology_and_tooling/chatbot_development/m1-03-api-integration-basics.md
@@ -1,0 +1,206 @@
+---
+name: API Integration Basics
+dependsOn:
+  - technology_and_tooling.chatbot_development.m1-02-llm-fundamentals
+tags: [chatbots, python, api]
+learningOutcomes:
+  - Set up OpenAI API credentials securely.
+  - Make API calls to generate chatbot responses.
+  - Understand the request and response structure of the Chat Completions API.
+  - Implement production-ready error handling with retries and exponential backoff.
+  - Understand rate limits and cost management strategies.
+attribution:
+  - citation: >
+      Oxford AI Competency Centre (2026). Chatbot Development Course.
+    url: https://github.com/OxfordCompetencyCenters/aicc_chatbot_modules
+    license: CC-BY-4.0
+---
+
+With the conceptual foundations in place, it's time to write code. In this section you'll set up the OpenAI API, make your first chatbot request, understand the structure of what goes in and what comes back, and build error handling that's robust enough for production use.
+
+## Setting Up the OpenAI API
+
+Before you can make API calls, you need an account and an API key. Visit [platform.openai.com](https://platform.openai.com), create an account, and verify your email. Once logged in, navigate to the API Keys section and create a new secret key.
+
+This key is a secret — treat it like a password. Never hardcode it in your source files, and never commit it to version control. The standard approach is to store it in an environment variable:
+
+```bash
+export OPENAI_API_KEY='sk-...'
+```
+
+In production systems, you'd use a dedicated secret management service like AWS Secrets Manager or HashiCorp Vault, but environment variables are fine for development.
+
+Next, install the Python client library:
+
+```bash
+pip install openai
+```
+
+You should also set spending limits in the OpenAI dashboard. This is your safety net — a bug that causes an infinite loop of API calls can rack up significant charges before you notice. Set a monthly budget that's appropriate for your usage, and monitor it regularly.
+
+## Your First API Call
+
+Here is a minimal working example that sends a message to the LLM and prints the response:
+
+```python
+import openai
+import os
+
+openai.api_key = os.getenv("OPENAI_API_KEY")
+
+response = openai.ChatCompletion.create(
+    model="gpt-3.5-turbo",
+    messages=[
+        {"role": "system", "content": "You are a helpful assistant."},
+        {"role": "user", "content": "What is a chatbot?"}
+    ]
+)
+
+answer = response.choices[0].message.content
+print(answer)
+```
+
+The `messages` parameter is a list of message objects, each with a `role` and `content`. There are three roles. The `system` message comes first and defines the chatbot's behaviour — its personality, capabilities, and constraints. The `user` messages represent what the human has said. The `assistant` messages represent what the chatbot has previously replied. By including a sequence of alternating user and assistant messages, you provide the model with conversation history — but we'll get to that in the next section.
+
+For now, notice that this example sends just two messages: a system prompt and a single user message. The model responds as if this is the very first (and only) thing the user has said, because it is. There's no memory of prior interactions. This is a stateless call.
+
+## Understanding the Request and Response
+
+It's worth looking at the full structure of what the API sends and receives, because you'll work with these data structures constantly.
+
+A request looks like this:
+
+```python
+{
+    "model": "gpt-3.5-turbo",
+    "messages": [
+        {"role": "system", "content": "You are..."},
+        {"role": "user", "content": "Hello"},
+        {"role": "assistant", "content": "Hi!"},
+        {"role": "user", "content": "How are you?"}
+    ],
+    "temperature": 0.7,
+    "max_tokens": 150
+}
+```
+
+The `model` field selects which LLM to use. The `messages` array is the conversation so far — the model sees all of it and generates a response that continues the conversation. The optional parameters (`temperature`, `max_tokens`, etc.) control how the response is generated, as we discussed in the previous section.
+
+The response comes back as a JSON object:
+
+```python
+{
+    "id": "chatcmpl-abc123",
+    "object": "chat.completion",
+    "created": 1677652288,
+    "model": "gpt-3.5-turbo-0301",
+    "choices": [{
+        "index": 0,
+        "message": {
+            "role": "assistant",
+            "content": "I'm doing well, thank you!"
+        },
+        "finish_reason": "stop"
+    }],
+    "usage": {
+        "prompt_tokens": 20,
+        "completion_tokens": 8,
+        "total_tokens": 28
+    }
+}
+```
+
+The three fields you'll use most are `choices[0].message.content` (the actual text of the response), `finish_reason` (whether the response completed naturally or was cut off by the token limit), and `usage` (the token counts for this request).
+
+The `usage` field deserves special attention. It tells you exactly how many tokens went in (`prompt_tokens`) and how many came out (`completion_tokens`). In production, you should log this for every request. It's your primary tool for understanding costs, spotting unexpectedly expensive conversations, and optimizing your token budget. If `finish_reason` is `"length"` rather than `"stop"`, the response was truncated because it hit `max_tokens` — you may want to retry with a higher limit or handle the incomplete response gracefully in your UI.
+
+## Error Handling for Production
+
+API calls can fail for many reasons. The OpenAI service might be temporarily overloaded, your account might hit a rate limit, your API key might be invalid, or your request might be malformed. A production chatbot needs to handle all of these gracefully, rather than crashing or showing a raw error to the user.
+
+The most common errors you'll encounter are:
+
+- `RateLimitError` — You've exceeded your allowed number of requests or tokens per minute.
+- `APIError` — Something went wrong on OpenAI's side.
+- `Timeout` — The request took too long to complete.
+- `AuthenticationError` — Your API key is invalid or missing.
+- `InvalidRequestError` — Your request was malformed (e.g., too many tokens, invalid model name).
+
+The standard pattern for handling transient errors (rate limits, temporary API issues) is **exponential backoff**: if the first attempt fails, wait 1 second and retry; if the second attempt fails, wait 2 seconds; then 4 seconds, and so on. This gives the service time to recover without overwhelming it with immediate retries.
+
+Here's a robust implementation:
+
+```python
+import openai
+import time
+from openai.error import RateLimitError, APIError
+
+def chat_with_retry(messages, max_retries=3):
+    for attempt in range(max_retries):
+        try:
+            response = openai.ChatCompletion.create(
+                model="gpt-3.5-turbo",
+                messages=messages,
+                timeout=30
+            )
+            return response.choices[0].message.content
+
+        except RateLimitError:
+            if attempt < max_retries - 1:
+                wait_time = 2 ** attempt
+                print(f"Rate limited. Waiting {wait_time}s...")
+                time.sleep(wait_time)
+            else:
+                return "I'm experiencing high demand. Please try again."
+
+        except APIError as e:
+            print(f"OpenAI API error: {e}")
+            return "I'm having technical difficulties. Please try again."
+
+        except Exception as e:
+            print(f"Unexpected error: {e}")
+            return "Something went wrong. Please try again."
+```
+
+A few things to note about this code. The `timeout=30` parameter ensures that a hung API call won't block your application indefinitely. The exponential backoff (`2 ** attempt`) spaces out retries progressively. And the error messages returned to the user are friendly and don't expose internal details. In a real production system, you'd also log these errors to a monitoring service so you can track failure rates and respond to outages. We'll cover monitoring and observability in Module 6.
+
+## Rate Limits and Cost Management
+
+OpenAI enforces rate limits on API usage, measured in both requests per minute and tokens per minute. These limits vary by account tier:
+
+| Tier | Requests/min | Tokens/min |
+|------|--------------|------------|
+| Free Trial | 3 | 40,000 |
+| Pay-as-you-go (new) | 60 | 150,000 |
+| Pay-as-you-go (established) | 3,500 | 90,000 |
+
+Your limits increase as you build a spending history with OpenAI. A brand-new account is heavily restricted, which can be frustrating during development. If you're building a production application, you'll want to plan for these limits and implement request queuing to handle bursts gracefully.
+
+Understanding costs is equally important. GPT-3.5-turbo charges approximately $0.0005 per 1,000 input tokens and $0.0015 per 1,000 output tokens. To put that in perspective: if your chatbot handles 100 conversations per day, each averaging 1,000 total tokens, your daily cost is about $0.10 and your monthly cost is about $3.00. That's quite affordable — but costs can escalate quickly if conversations are long, if you use more expensive models like GPT-4, or if a bug causes unnecessary API calls.
+
+There are several strategies for keeping costs under control. Use GPT-3.5 for simpler tasks and reserve GPT-4 for situations that genuinely benefit from its greater capability. Set `max_tokens` on every request to prevent unexpectedly long responses. Prune conversation history to avoid sending thousands of tokens of old messages with every new request (we'll cover this in detail shortly). Implement response caching so identical questions don't trigger redundant API calls (Module 3). And always, always log your token usage so you can spot anomalies before they become expensive surprises.
+
+::::challenge{id=m1-03-first-call title="Make Your First API Call"}
+
+Now it's your turn. Set up your environment and make a simple API call.
+
+1. Install the OpenAI Python library if you haven't already:
+
+```bash
+pip install openai
+```
+
+2. Set your API key as an environment variable.
+
+3. Write a short script that sends a question to the API and prints the response. Try changing the system prompt to see how it affects the output. For example, compare the response you get with `"You are a helpful assistant"` versus `"You are a pirate who only speaks in nautical metaphors"`.
+
+4. Modify your script to print the `usage` field from the response. How many tokens did your prompt use? How many tokens were in the response?
+
+5. Try adjusting the `temperature` parameter. Make the same request three times at temperature 0.0, then three times at temperature 1.5. How does the variation in responses change?
+
+These experiments will give you a hands-on feel for how the API behaves — something that's hard to get from reading alone.
+::::
+
+## Hands-on practical
+
+Work through the accompanying notebook: [`module_1/03-api-integration-basics.ipynb`](https://github.com/OxfordCompetencyCenters/aicc_chatbot_modules/blob/main/module_1/03-api-integration-basics.ipynb). It walks through your first chat completion call, response-object inspection, system-prompt comparison, and a retry-with-exponential-backoff implementation.

--- a/technology_and_tooling/chatbot_development/m1-03-api-integration-basics.md
+++ b/technology_and_tooling/chatbot_development/m1-03-api-integration-basics.md
@@ -13,6 +13,7 @@ attribution:
   - citation: >
       Oxford AI Competency Centre (2026). Chatbot Development Course.
     url: https://github.com/OxfordCompetencyCenters/aicc_chatbot_modules
+    image: https://github.com/OxfordCompetencyCenters.png
     license: CC-BY-4.0
 ---
 

--- a/technology_and_tooling/chatbot_development/m1-04-building-stateless-and-stateful-chatbots.md
+++ b/technology_and_tooling/chatbot_development/m1-04-building-stateless-and-stateful-chatbots.md
@@ -1,7 +1,7 @@
 ---
 name: Building Stateless and Stateful Chatbots
 dependsOn:
-  - technology_and_tooling.chatbot_development.m1-03-api-integration-basics
+  - technology_and_tooling.chatbot_development.m1-01-introduction-to-modern-chatbots
 tags: [chatbots, python]
 learningOutcomes:
   - Build a stateless chatbot for FAQ-style interactions.

--- a/technology_and_tooling/chatbot_development/m1-04-building-stateless-and-stateful-chatbots.md
+++ b/technology_and_tooling/chatbot_development/m1-04-building-stateless-and-stateful-chatbots.md
@@ -1,0 +1,432 @@
+---
+name: Building Stateless and Stateful Chatbots
+dependsOn:
+  - technology_and_tooling.chatbot_development.m1-03-api-integration-basics
+tags: [chatbots, python]
+learningOutcomes:
+  - Build a stateless chatbot for FAQ-style interactions.
+  - Build a stateful chatbot that maintains conversation history.
+  - Implement token budget management to control costs and stay within context limits.
+  - Craft effective system prompts for different use cases.
+attribution:
+  - citation: >
+      Oxford AI Competency Centre (2026). Chatbot Development Course.
+    url: https://github.com/OxfordCompetencyCenters/aicc_chatbot_modules
+    license: CC-BY-4.0
+---
+
+In the previous section you made individual API calls. Now we'll wrap that capability into reusable chatbot classes — first a stateless one, then a stateful one — and tackle the practical challenges that arise when conversations get long. We'll also look closely at system prompts, which are your primary tool for shaping a chatbot's behaviour.
+
+## Building a Stateless Chatbot
+
+A stateless chatbot is the simplest architecture: each user message is handled independently, with no memory of previous exchanges. The implementation is straightforward — store a system prompt, and on every call, send just the system prompt and the user's current message to the API.
+
+```python
+import openai
+import os
+
+openai.api_key = os.getenv("OPENAI_API_KEY")
+
+class StatelessChatbot:
+    def __init__(self, system_prompt):
+        self.system_prompt = system_prompt
+
+    def chat(self, user_message):
+        """Process a single message without history."""
+        response = openai.ChatCompletion.create(
+            model="gpt-3.5-turbo",
+            messages=[
+                {"role": "system", "content": self.system_prompt},
+                {"role": "user", "content": user_message}
+            ],
+            temperature=0.7
+        )
+        return response.choices[0].message.content
+```
+
+You can use it like this:
+
+```python
+bot = StatelessChatbot("You are a Python programming expert.")
+print(bot.chat("What is a list comprehension?"))
+print(bot.chat("Can you show an example?"))
+```
+
+Try running this and pay attention to what happens with the second message. The bot has no idea what "an example" refers to, because it has no memory of the first exchange. It might give you an example of something completely unrelated, or ask you to clarify. This is the fundamental limitation of stateless design: every message exists in isolation.
+
+For certain use cases, that's perfectly fine. A FAQ bot for a restaurant ("What are your hours?", "Do you take reservations?", "Where are you located?") works well as a stateless system because each question is self-contained. But the moment users need to have a conversation — asking follow-up questions, referring back to earlier context, building on previous answers — you need state.
+
+## Building a Stateful Chatbot
+
+A stateful chatbot solves the memory problem by maintaining a list of all messages exchanged so far and including that list in every API call. The model sees the entire conversation history and can respond in context.
+
+```python
+class StatefulChatbot:
+    def __init__(self, system_prompt):
+        self.system_prompt = system_prompt
+        self.conversation_history = [
+            {"role": "system", "content": system_prompt}
+        ]
+
+    def chat(self, user_message):
+        """Process message with full conversation history."""
+        self.conversation_history.append({
+            "role": "user",
+            "content": user_message
+        })
+
+        response = openai.ChatCompletion.create(
+            model="gpt-3.5-turbo",
+            messages=self.conversation_history,
+            temperature=0.7
+        )
+
+        assistant_message = response.choices[0].message.content
+        self.conversation_history.append({
+            "role": "assistant",
+            "content": assistant_message
+        })
+
+        return assistant_message
+
+    def get_history(self):
+        """Return conversation history, excluding the system prompt."""
+        return self.conversation_history[1:]
+
+    def reset(self):
+        """Clear conversation history and start fresh."""
+        self.conversation_history = [
+            {"role": "system", "content": self.system_prompt}
+        ]
+```
+
+The key difference is the `conversation_history` list. It starts with just the system prompt. Each time the user sends a message, we append it to the list. Each time the model responds, we append that too. When we make the next API call, we send the entire list, so the model can see everything that's been said.
+
+```python
+bot = StatefulChatbot("You are a Python programming expert.")
+print(bot.chat("What is a list comprehension?"))
+print(bot.chat("Can you show an example?"))  # Now it knows we're talking about list comprehensions
+print(f"History: {len(bot.get_history())} messages")
+```
+
+This time, the second message works as expected. The model sees the full conversation, understands that "an example" refers to list comprehensions, and provides a relevant code sample. Follow-up questions like "What if I want to filter?", "Is that faster than a for loop?", and "Can you make it more complex?" all work naturally because the context is preserved.
+
+The `reset()` method clears the history, which is useful when a user wants to start a new topic or when you want to free up token budget. In a web application, you'd typically create a new `StatefulChatbot` instance (or call `reset()`) for each new conversation session.
+
+## Managing Token Budgets
+
+The stateful chatbot above has a problem: the conversation history grows without bound. Every turn adds more messages, and every message adds more tokens. Since the full history is sent with every API call, both the cost and the latency increase with every exchange.
+
+To see how quickly this adds up, consider a conversation where each turn (one user message plus one assistant response) averages 200 tokens. The system prompt adds another 100 tokens. Here's how the total tokens per request grow:
+
+```
+Turn 1:  100 (system) + 50 (user) + 150 (assistant) = 300 tokens
+Turn 2:  300 (previous) + 50 (user) + 150 (assistant) = 500 tokens
+Turn 5:  everything so far ≈ 1,100 tokens
+Turn 10: everything so far ≈ 2,100 tokens
+Turn 20: everything so far ≈ 4,100 tokens
+```
+
+With GPT-3.5-turbo's 16K token context window, you'd hit the limit around turn 40–50 in a typical conversation. With a more detailed system prompt or longer messages, you'd hit it sooner. And you're paying for all of those tokens on every single API call — not just the new ones.
+
+The simplest solution is to set a token budget and prune the oldest messages when the conversation exceeds it. Here's an implementation that does this using OpenAI's `tiktoken` library to count tokens accurately:
+
+```python
+import tiktoken
+
+class TokenAwareChatbot(StatefulChatbot):
+    def __init__(self, system_prompt, max_history_tokens=2000):
+        super().__init__(system_prompt)
+        self.max_history_tokens = max_history_tokens
+        self.encoding = tiktoken.encoding_for_model("gpt-3.5-turbo")
+
+    def count_tokens(self, messages):
+        """Count the total tokens in a list of messages."""
+        total = 0
+        for message in messages:
+            total += len(self.encoding.encode(message["content"]))
+        return total
+
+    def chat(self, user_message):
+        self.conversation_history.append({
+            "role": "user",
+            "content": user_message
+        })
+
+        # Prune oldest messages (but never the system prompt) if over budget
+        while self.count_tokens(self.conversation_history) > self.max_history_tokens:
+            if len(self.conversation_history) > 3:
+                self.conversation_history.pop(1)  # Remove oldest user message
+                self.conversation_history.pop(1)  # Remove oldest assistant message
+            else:
+                break
+
+        response = openai.ChatCompletion.create(
+            model="gpt-3.5-turbo",
+            messages=self.conversation_history
+        )
+
+        assistant_message = response.choices[0].message.content
+        self.conversation_history.append({
+            "role": "assistant",
+            "content": assistant_message
+        })
+
+        return assistant_message
+```
+
+To use `tiktoken`, install it with `pip install tiktoken`. The `encoding_for_model` function returns the tokenizer that matches a specific model, so your token counts will be accurate.
+
+This pruning approach works, but it's crude. Dropping old messages means the bot loses memory of the early parts of the conversation. If a user established important context at the beginning — "I'm running Windows 11 and using Python 3.12" — that context disappears once those messages get pruned. In Module 4, we'll explore more sophisticated strategies: summarizing older messages into a compact form that preserves key information, selectively retaining important context, and using retrieval-based approaches to recall relevant parts of the conversation history on demand.
+
+## Crafting Effective System Prompts
+
+The system prompt is the single most powerful tool you have for controlling a chatbot's behaviour. It's the first message in every conversation, it's included in every API call, and it tells the model who it is, what it can do, how it should communicate, and what it should avoid.
+
+A good system prompt has several components. It starts with a **role definition** — who is this chatbot? Not just "a helpful assistant," but a specific character with a specific job. It defines **capabilities** — what the chatbot can and should help with. It specifies **personality and tone** — is it formal or casual, brief or detailed, cautious or enthusiastic? It sets **constraints** — what the chatbot should never do, what topics it should avoid, how it should handle questions outside its scope. And for complex workflows, it includes **procedures** — step-by-step instructions for how to handle specific situations.
+
+Here's an example that brings all of these elements together:
+
+```python
+system_prompt = """You are an expert customer support agent for TechCorp,
+a software company specializing in project management tools.
+
+Your capabilities:
+- Answer questions about our product features
+- Troubleshoot common technical issues
+- Guide users through setup and configuration
+- Escalate complex issues to human agents when needed
+
+Your personality:
+- Professional yet friendly
+- Patient and empathetic
+- Clear and concise in explanations
+
+Important guidelines:
+- Never make up information about features that don't exist
+- If you don't know something, admit it and offer to connect them with someone who does
+- Always prioritize the user's success and satisfaction
+- Keep responses under 150 words unless detailed explanation is needed
+
+When handling issues:
+1. Acknowledge the user's problem
+2. Ask clarifying questions if needed
+3. Provide step-by-step solutions
+4. Verify the issue is resolved
+"""
+```
+
+Compare this to a system prompt that just says "You are a helpful assistant." The detailed version produces dramatically different behaviour. The chatbot will stay in character, follow the prescribed workflow, decline to speculate about features it doesn't know about, and proactively offer to escalate when it's out of its depth.
+
+The right system prompt depends entirely on the use case. A FAQ bot should be brief and direct, with clear boundaries on what topics it handles. A technical support bot should ask clarifying questions before jumping to solutions. An educational tutor should never give direct answers — instead, it should guide students to discover solutions through Socratic questioning. A sales assistant should be enthusiastic and persuasive while remaining honest.
+
+Here are four system prompts that illustrate how different goals lead to different designs:
+
+```python
+# FAQ Bot — stateless, brief, boundary-aware
+"""You are a FAQ assistant for a restaurant.
+Answer questions about hours, location, menu, and reservations.
+Be brief and friendly. If asked something outside these topics,
+politely redirect to calling the restaurant."""
+
+# Technical Support — stateful, methodical
+"""You are a senior technical support engineer.
+Help users debug issues with detailed, step-by-step guidance.
+Ask clarifying questions before suggesting solutions.
+Include code examples when relevant."""
+
+# Educational Tutor — stateful, Socratic
+"""You are a patient programming tutor.
+Never give direct answers - guide students to discover solutions.
+Ask Socratic questions. Encourage experimentation.
+Celebrate progress and provide hints when students are stuck."""
+
+# Sales Assistant — stateful, personality-driven
+"""You are an enthusiastic sales assistant for an e-commerce store.
+Help customers find products matching their needs.
+Ask about preferences, budget, and use cases.
+Suggest 2-3 options with pros/cons. Be persuasive but honest."""
+```
+
+When writing system prompts, be as specific as possible. Vague instructions like "be helpful" give the model too much latitude. Specific instructions like "answer questions about X, Y, and Z; if asked about anything else, say you can only help with those topics and suggest they contact support@example.com" produce consistent, predictable behaviour.
+
+Keep your system prompts under 500 words. Every word costs tokens, and the system prompt is included in every single API call. A verbose system prompt that consumes 1,000 tokens will add $0.0005 to every request — which adds up quickly at scale.
+
+Finally, test your system prompts thoroughly. Small wording changes can produce surprisingly different behaviour. Try edge cases: what happens if the user asks about a topic outside the chatbot's scope? What if they're rude? What if they try to override the system prompt? Iterate on your prompts the same way you'd iterate on code.
+
+::::challenge{id=m1-04-ex1 title="Build a Stateless FAQ Bot"}
+
+Create a stateless chatbot for a fictional coffee shop called "DevBrew" that specializes in coffee for programmers. The shop is open 6 AM to 10 PM daily, located at 123 Code Street, and its menu highlights include Espresso, Cold Brew, and the "Debug Latte."
+
+Write a system prompt that gives the bot the information it needs, defines its personality, and tells it how to handle off-topic questions. Then implement the `StatelessChatbot` class:
+
+```python
+import openai
+import os
+
+openai.api_key = os.getenv("OPENAI_API_KEY")
+
+system_prompt = """
+[YOUR SYSTEM PROMPT HERE]
+"""
+
+class StatelessChatbot:
+    def __init__(self, system_prompt):
+        # YOUR CODE HERE
+        pass
+
+    def chat(self, user_message):
+        # YOUR CODE HERE
+        pass
+
+# Test your bot
+bot = StatelessChatbot(system_prompt)
+print(bot.chat("What are your hours?"))
+print(bot.chat("Do you have cold brew?"))
+print(bot.chat("What's the meaning of life?"))  # Off-topic — how does it respond?
+```
+
+Once it's working, try these extensions: add the error handling pattern from the previous section, print the token usage for each call, and experiment with different temperature values to see how they affect the responses.
+::::
+
+::::challenge{id=m1-04-ex2 title="Add Conversation History"}
+
+Extend your coffee shop bot to maintain conversation history. Implement the `StatefulChatbot` class with `chat()`, `get_history()`, and `reset()` methods:
+
+```python
+class StatefulChatbot:
+    def __init__(self, system_prompt):
+        self.system_prompt = system_prompt
+        self.conversation_history = []
+        # TODO: Initialize with system prompt
+
+    def chat(self, user_message):
+        # TODO: Append user message to history
+        # TODO: Make API call with full history
+        # TODO: Append assistant response to history
+        # TODO: Return the response
+        pass
+
+    def get_history(self):
+        # TODO: Return history excluding system prompt
+        pass
+
+    def reset(self):
+        # TODO: Clear history, keeping system prompt
+        pass
+```
+
+Test it with a sequence of messages that require context:
+
+```python
+bot = StatefulChatbot(system_prompt)
+print(bot.chat("Tell me about your cold brew"))
+print(bot.chat("How much does that cost?"))  # "that" should refer to cold brew
+print(bot.chat("I'll take two"))             # Should understand the order
+
+assert len(bot.get_history()) == 6  # 3 user + 3 assistant messages
+
+bot.reset()
+assert len(bot.get_history()) == 0
+```
+
+The key test is whether follow-up messages that use pronouns ("that", "it", "those") work correctly. If they do, your conversation history is working.
+::::
+
+::::challenge{id=m1-04-ex3 title="Implement Token Budgeting"}
+
+Add token counting and automatic history pruning to your stateful chatbot. You'll need to install `tiktoken`:
+
+```bash
+pip install tiktoken
+```
+
+Then implement the `TokenManagedChatbot` class:
+
+```python
+import tiktoken
+
+class TokenManagedChatbot(StatefulChatbot):
+    def __init__(self, system_prompt, max_history_tokens=1000):
+        super().__init__(system_prompt)
+        self.max_history_tokens = max_history_tokens
+        self.encoding = tiktoken.encoding_for_model("gpt-3.5-turbo")
+
+    def count_tokens(self, messages):
+        # TODO: Count total tokens across all messages
+        pass
+
+    def prune_history(self):
+        # TODO: Remove oldest user/assistant pairs until under budget
+        # Never remove the system prompt (index 0)
+        pass
+
+    def chat(self, user_message):
+        self.conversation_history.append({
+            "role": "user",
+            "content": user_message
+        })
+
+        self.prune_history()
+
+        response = openai.ChatCompletion.create(
+            model="gpt-3.5-turbo",
+            messages=self.conversation_history
+        )
+
+        assistant_message = response.choices[0].message.content
+        self.conversation_history.append({
+            "role": "assistant",
+            "content": assistant_message
+        })
+
+        return assistant_message
+```
+
+Test it with a long conversation and observe what happens:
+
+```python
+bot = TokenManagedChatbot(system_prompt, max_history_tokens=500)
+for i in range(10):
+    response = bot.chat(f"Tell me about coffee drink number {i}")
+    token_count = bot.count_tokens(bot.conversation_history)
+    print(f"Turn {i+1}: {len(bot.get_history())} messages, {token_count} tokens")
+```
+
+Watch how the message count stabilises as old messages get pruned. Think about what information is being lost. If the user mentioned something important in turn 1 and you're now on turn 8, is that information still available? What would happen if `max_history_tokens` were set very low — say, 200? These are the questions that motivate the more sophisticated memory strategies we'll explore in Module 4.
+::::
+
+::::challenge{id=m1-04-checkpoint title="Project Checkpoint 1: Capstone Foundation"}
+
+This is a good time to begin your capstone project — the production-ready chatbot you'll build incrementally throughout the course.
+
+Choose a domain that interests you. It could be customer support for a product you know well, a tutor for a subject you're studying, a scheduling assistant, an HR onboarding bot, or anything else that involves multi-turn conversation. Define 3–5 core capabilities your chatbot should have.
+
+By the end of this module, you should have:
+
+- A working `StatefulChatbot` class with conversation history
+- A thoughtfully designed system prompt with a written rationale for your choices
+- Basic token management
+- Error handling with retries
+- A test conversation (at least 10 turns) that demonstrates your chatbot's core capabilities
+
+This foundation will grow significantly as you add retrieval (Module 2), caching (Module 3), memory management (Module 4), and the other capabilities covered in later modules.
+::::
+
+## Summary and What's Next
+
+In this module, you've built a solid foundation for chatbot development. You understand how chatbots evolved from simple pattern matching to LLM-powered conversation, how tokens and context windows constrain what's possible, how to interact with the OpenAI API reliably, and how to build both stateless and stateful conversation systems with token management and effective system prompts.
+
+In Module 2, we tackle one of the biggest limitations of LLMs: they only know what they were trained on. If your chatbot needs to answer questions about your company's documentation, a specific textbook, or today's news, the model's training data won't help. Retrieval-Augmented Generation (RAG) solves this by letting your chatbot search through external documents, retrieve relevant passages, and ground its responses in real, authoritative sources. It's one of the most powerful and practical patterns in production chatbot development, and it builds directly on the stateful conversation architecture you've just built.
+
+## Additional Resources
+
+- [OpenAI API Documentation](https://platform.openai.com/docs) — The official reference for all API features.
+- [tiktoken](https://github.com/openai/tiktoken) — OpenAI's tokenizer library, essential for accurate token counting.
+- [OpenAI Playground](https://platform.openai.com/playground) — A web-based interface for experimenting with prompts and parameters without writing code.
+- "The Illustrated Transformer" — A visual, accessible guide to the architecture behind modern LLMs.
+- "A Survey of Large Language Models" — An academic overview of the field for those who want to go deeper.
+
+## Hands-on practical
+
+Work through the accompanying notebook: [`module_1/04-building-stateless-and-stateful-chatbots.ipynb`](https://github.com/OxfordCompetencyCenters/aicc_chatbot_modules/blob/main/module_1/04-building-stateless-and-stateful-chatbots.ipynb). It walks through the DevBrew stateless bot, a stateful follow-up bot, and a token-managed version that prunes history when it exceeds a configurable budget.

--- a/technology_and_tooling/chatbot_development/m1-04-building-stateless-and-stateful-chatbots.md
+++ b/technology_and_tooling/chatbot_development/m1-04-building-stateless-and-stateful-chatbots.md
@@ -12,6 +12,7 @@ attribution:
   - citation: >
       Oxford AI Competency Centre (2026). Chatbot Development Course.
     url: https://github.com/OxfordCompetencyCenters/aicc_chatbot_modules
+    image: https://github.com/OxfordCompetencyCenters.png
     license: CC-BY-4.0
 ---
 

--- a/technology_and_tooling/chatbot_development/m2-01-the-rag-paradigm.md
+++ b/technology_and_tooling/chatbot_development/m2-01-the-rag-paradigm.md
@@ -1,0 +1,136 @@
+---
+name: The RAG Paradigm
+dependsOn:
+  - technology_and_tooling.chatbot_development.m1-04-building-stateless-and-stateful-chatbots
+tags: [chatbots, rag]
+learningOutcomes:
+  - Explain what Retrieval-Augmented Generation is and how it works.
+  - Identify the limitations of base LLMs that RAG addresses.
+  - Describe the two phases of a RAG system (indexing and retrieval).
+  - Distinguish between RAG and fine-tuning and know when to use each.
+attribution:
+  - citation: >
+      Oxford AI Competency Centre (2026). Chatbot Development Course.
+    url: https://github.com/OxfordCompetencyCenters/aicc_chatbot_modules
+    license: CC-BY-4.0
+---
+
+In Module 1, you built a chatbot that can hold conversations and manage its context window. But that chatbot has a fundamental limitation: it only knows what was in the LLM's training data. Ask it about your company's internal documentation, last week's policy changes, or the specifics of your product catalogue, and it will either refuse to answer or — worse — confidently make something up. Retrieval-Augmented Generation (RAG) solves this problem, and it's the single most important pattern in production chatbot development.
+
+## What is Retrieval-Augmented Generation?
+
+RAG combines information retrieval with text generation. Instead of relying solely on what the LLM learned during training, a RAG system retrieves relevant documents from an external knowledge base and includes them in the prompt. The LLM then generates a response grounded in those retrieved documents, rather than drawing entirely on its internal parameters.
+
+Think of it like an open-book exam. Without RAG, the LLM is taking a closed-book test — it can only answer from memory, and its memory has a cutoff date and no knowledge of your private data. With RAG, the LLM gets to look things up before answering.
+
+The process works in six steps:
+
+```
+1. User asks a question
+   ↓
+2. Convert the question to a vector embedding
+   ↓
+3. Search a vector database for similar documents
+   ↓
+4. Retrieve the top K most relevant chunks
+   ↓
+5. Inject the retrieved context into the LLM prompt
+   ↓
+6. LLM generates a response grounded in the retrieved documents
+```
+
+The critical insight is that the LLM doesn't "know" the information in any deep sense. It reads the retrieved documents at inference time, just as a human would read reference material before answering a question. This means you can update your knowledge base at any time — add new documents, remove outdated ones, correct errors — and the chatbot's responses reflect those changes immediately, without any retraining.
+
+## Why RAG? The Limitations It Solves
+
+Base LLMs, no matter how capable, have four limitations that make them insufficient for most production use cases.
+
+The first is **knowledge cutoff**. Every LLM has a training data cutoff date. GPT-4's training data, for example, stops at a specific point in time. Anything that happened after that date — new product releases, updated policies, recent events — simply doesn't exist in the model's knowledge. For a customer support chatbot that needs to reference the latest version of your documentation, this is a deal-breaker.
+
+The second is **no access to private or proprietary knowledge**. Even within its training period, the LLM has never seen your company's internal documents, your customer database, your HR policies, or your product specifications. It cannot answer questions about information it has never encountered, no matter how well you prompt it.
+
+The third is **hallucination**. When an LLM doesn't know the answer to a question, it doesn't say "I don't know." It generates a plausible-sounding response based on patterns in its training data. For general knowledge, this often works well enough. But for specific, factual questions — "What is our return policy for electronics purchased after January 2024?" — a hallucinated answer can be confidently wrong and actively harmful.
+
+The fourth is **inability to cite sources**. Even when an LLM gives a correct answer, it can't tell you where that information came from. In high-stakes domains like legal, medical, or financial services, the inability to audit and verify responses is a serious problem.
+
+RAG addresses all four of these limitations. It gives the chatbot access to current documents (solving the knowledge cutoff). It can index your proprietary data (solving the private knowledge gap). It grounds responses in actual documents, dramatically reducing hallucination. And it can cite exactly which documents it drew from, enabling verification and building user trust.
+
+## RAG Architecture: Indexing and Retrieval
+
+A RAG system operates in two distinct phases.
+
+The **indexing phase** happens offline, before any user interacts with the system. You take your document corpus — PDFs, text files, web pages, database records, whatever you have — and process it through a pipeline: clean the text, split it into chunks, convert each chunk into a vector embedding, and store those embeddings in a vector database alongside the original text and any metadata. This is a one-time operation (or periodic, if your documents change).
+
+The **retrieval phase** happens in real time, every time a user asks a question. The user's query is converted into a vector embedding using the same model that embedded the documents. That query vector is compared against all the document vectors in the database to find the most similar ones. The top K results are retrieved, and their text is injected into the LLM prompt as context. The LLM then generates a response based on that context.
+
+Here is the complete architecture:
+
+```
+┌─────────────────┐
+│  Document       │
+│  Corpus         │
+└────────┬────────┘
+         │
+         ▼
+┌─────────────────┐
+│ Preprocessing   │  ← Text cleaning, chunking
+└────────┬────────┘
+         │
+         ▼
+┌─────────────────┐
+│ Embedding       │  ← Convert to vectors
+│ Generation      │
+└────────┬────────┘
+         │
+         ▼
+┌─────────────────┐
+│ Vector Database │  ← Store and index
+└────────┬────────┘
+         │
+    [Index Time]
+         │
+         │           [Query Time]
+         │                │
+         │    ┌───────────▼──────────┐
+         │    │ User Query → Embed   │
+         │    └───────────┬──────────┘
+         │                │
+         │    ┌───────────▼──────────┐
+         └───►│ Similarity Search    │
+              └───────────┬──────────┘
+                          │
+              ┌───────────▼──────────┐
+              │ Retrieve Top K       │
+              └───────────┬──────────┘
+                          │
+              ┌───────────▼──────────┐
+              │ Inject into Prompt   │
+              └───────────┬──────────┘
+                          │
+              ┌───────────▼──────────┐
+              │ Generate Response    │
+              └──────────────────────┘
+```
+
+The embedding generation step is crucial, and it happens twice: once for documents during indexing, and once for user queries during retrieval. Both must use the same embedding model — if you embed your documents with `text-embedding-3-small` and your queries with a different model, the vectors won't be comparable and search will fail.
+
+## RAG vs Fine-Tuning
+
+A common question is: "Should I fine-tune the model on my data instead of using RAG?" The short answer is that RAG and fine-tuning solve different problems, and for most chatbot use cases, RAG is the right choice.
+
+| Aspect | RAG | Fine-Tuning |
+|--------|-----|-------------|
+| **Purpose** | Add external knowledge and facts | Change behaviour, style, or format |
+| **Update speed** | Instant (update your documents) | Slow (retrain the model) |
+| **Cost** | Low (inference only) | High (training compute) |
+| **Complexity** | Moderate | High |
+| **Transparency** | Can cite sources | Black box |
+| **Best for** | Knowledge bases, document Q&A, customer support | Specific tone/style, domain-specific task formats |
+
+Fine-tuning changes *how* the model behaves — its tone, its response format, its approach to certain types of tasks. RAG changes *what* the model knows — the factual information it can draw on. If you need your chatbot to answer questions about your product documentation, that's a RAG problem. If you need your chatbot to respond in a very specific medical dialogue format, that might be a fine-tuning problem.
+
+The practical recommendation is to start with RAG. Many use cases that initially seem like they need fine-tuning can actually be solved with RAG combined with a well-designed system prompt. Fine-tuning is expensive, slow to iterate on, and creates a model that's harder to update. RAG is cheap, instantly updatable, and transparent. Only consider fine-tuning if you've exhausted what RAG and prompt engineering can do and still need specialised behaviour.
+
+## Hands-on practical
+
+Work through the accompanying notebook: [`module_2/01-the-rag-paradigm.ipynb`](https://github.com/OxfordCompetencyCenters/aicc_chatbot_modules/blob/main/module_2/01-the-rag-paradigm.ipynb). It walks through the knowledge-cutoff and hallucination problems first-hand, then contrasts them with a manual RAG call where reference text is supplied in the prompt.

--- a/technology_and_tooling/chatbot_development/m2-01-the-rag-paradigm.md
+++ b/technology_and_tooling/chatbot_development/m2-01-the-rag-paradigm.md
@@ -12,6 +12,7 @@ attribution:
   - citation: >
       Oxford AI Competency Centre (2026). Chatbot Development Course.
     url: https://github.com/OxfordCompetencyCenters/aicc_chatbot_modules
+    image: https://github.com/OxfordCompetencyCenters.png
     license: CC-BY-4.0
 ---
 

--- a/technology_and_tooling/chatbot_development/m2-02-vector-embeddings.md
+++ b/technology_and_tooling/chatbot_development/m2-02-vector-embeddings.md
@@ -12,6 +12,7 @@ attribution:
   - citation: >
       Oxford AI Competency Centre (2026). Chatbot Development Course.
     url: https://github.com/OxfordCompetencyCenters/aicc_chatbot_modules
+    image: https://github.com/OxfordCompetencyCenters.png
     license: CC-BY-4.0
 ---
 

--- a/technology_and_tooling/chatbot_development/m2-02-vector-embeddings.md
+++ b/technology_and_tooling/chatbot_development/m2-02-vector-embeddings.md
@@ -1,0 +1,183 @@
+---
+name: Vector Embeddings
+dependsOn:
+  - technology_and_tooling.chatbot_development.m2-01-the-rag-paradigm
+tags: [chatbots, rag, embeddings]
+learningOutcomes:
+  - Explain what vector embeddings are and how they capture semantic meaning.
+  - Create embeddings using the OpenAI Embeddings API.
+  - Measure similarity between embeddings using cosine similarity.
+  - Understand the practical implications of embedding dimensions and model choice.
+attribution:
+  - citation: >
+      Oxford AI Competency Centre (2026). Chatbot Development Course.
+    url: https://github.com/OxfordCompetencyCenters/aicc_chatbot_modules
+    license: CC-BY-4.0
+---
+
+The entire RAG pipeline depends on one fundamental capability: converting text into numbers in a way that preserves meaning. That's what vector embeddings do, and understanding them is essential for building effective retrieval systems.
+
+## What Are Vector Embeddings?
+
+An embedding is a dense vector — a list of floating-point numbers — that represents the semantic meaning of a piece of text. When you pass a sentence through an embedding model, you get back something like this:
+
+```
+Text: "The cat sat on the mat"
+Embedding: [0.02, -0.15, 0.43, 0.08, ..., 0.21]
+            └─────────── 1536 dimensions ──────────┘
+```
+
+Each number in the vector captures some aspect of the text's meaning. No single dimension corresponds to a human-readable concept like "about animals" or "describes a location" — the meaning is distributed across all dimensions. But the remarkable property of these vectors is that **texts with similar meanings produce similar vectors**. The embedding for "a feline rested on the rug" will be very close to the embedding for "the cat sat on the mat", even though the two sentences share almost no words.
+
+This is what makes embeddings useful for search. Traditional keyword search fails when users use different words than the documents. If your documentation says "automobile" and the user searches for "car", a keyword search finds nothing. With embeddings, those two words map to nearby points in vector space, and the search succeeds.
+
+## How Embeddings Capture Semantics
+
+Embedding models learn semantic relationships through exposure to enormous amounts of text during training. The resulting vector space has several powerful properties.
+
+**Synonyms map to similar vectors.** Words and phrases with the same meaning end up close together:
+
+```python
+"happy" → [0.2, 0.8, 0.1, ...]
+"joyful" → [0.21, 0.79, 0.11, ...]
+# Cosine similarity: 0.92 — very similar
+```
+
+**Context changes the embedding.** Modern embedding models are contextual, meaning the same word gets different embeddings depending on how it's used:
+
+```python
+"bank" in "river bank" → [0.5, 0.2, -0.3, ...]
+"bank" in "bank account" → [-0.2, 0.7, 0.4, ...]
+# Different meanings produce different vectors
+```
+
+**Semantic relationships are preserved geometrically.** The famous example is that `vector("king") - vector("man") + vector("woman") ≈ vector("queen")`. The direction from "man" to "king" (roughly: "add royalty") is the same as the direction from "woman" to "queen". This is a simplified illustration, but it demonstrates that embeddings capture meaningful relationships, not just surface-level word patterns.
+
+For RAG, this means that a user's question doesn't need to use the exact same words as the documents. "How do I reset my password?" will match a document titled "Account credential recovery procedure" because the underlying meaning is similar, even though the phrasing is completely different.
+
+## Creating Embeddings with the OpenAI API
+
+OpenAI provides several embedding models with different trade-offs:
+
+| Model | Dimensions | Cost (per 1M tokens) | Use Case |
+|-------|------------|---------------------|----------|
+| text-embedding-3-small | 1536 | $0.02 | Most use cases |
+| text-embedding-3-large | 3072 | $0.13 | Higher accuracy needed |
+| text-embedding-ada-002 | 1536 | $0.10 | Legacy (still good) |
+
+For most RAG applications, `text-embedding-3-small` is the best choice. It's inexpensive and produces high-quality embeddings. Only use `text-embedding-3-large` if you've tested both and found that the larger model produces meaningfully better retrieval for your specific data.
+
+Here's how to create an embedding for a single text:
+
+```python
+import openai
+import os
+
+openai.api_key = os.getenv("OPENAI_API_KEY")
+
+response = openai.Embedding.create(
+    model="text-embedding-3-small",
+    input="The quick brown fox jumps over the lazy dog"
+)
+
+embedding = response['data'][0]['embedding']
+print(f"Embedding dimensions: {len(embedding)}")   # 1536
+print(f"First 5 values: {embedding[:5]}")
+```
+
+When you need to embed multiple texts — which you will, frequently, during document indexing — batch them into a single API call. This is significantly more efficient than making one call per text:
+
+```python
+texts = [
+    "Python is a programming language",
+    "Java is also a programming language",
+    "I love pizza"
+]
+
+response = openai.Embedding.create(
+    model="text-embedding-3-small",
+    input=texts
+)
+
+embeddings = [item['embedding'] for item in response['data']]
+```
+
+The API can handle up to 2,048 texts in a single batch. For document indexing, you'll typically process your chunks in batches of 100–500 to stay comfortably within limits while maximising throughput.
+
+One critical rule: **always use the same embedding model for documents and queries.** If you embed your documents with `text-embedding-3-small` and then embed your user queries with `text-embedding-3-large`, the resulting vectors live in different vector spaces and comparing them is meaningless. Pick one model and use it consistently.
+
+## Measuring Similarity
+
+Once you have embeddings, you need a way to measure how similar two vectors are. The most common metric for text embeddings is **cosine similarity**, which measures the angle between two vectors on a scale from -1 (opposite directions) to 1 (same direction).
+
+```python
+import numpy as np
+
+def cosine_similarity(vec1, vec2):
+    """Measures the angle between two vectors. Range: -1 to 1."""
+    dot_product = np.dot(vec1, vec2)
+    norm1 = np.linalg.norm(vec1)
+    norm2 = np.linalg.norm(vec2)
+    return dot_product / (norm1 * norm2)
+```
+
+Cosine similarity is the standard choice for text embeddings because it measures direction rather than magnitude. Two vectors pointing in the same direction are considered similar regardless of their length. This matches how text embeddings work — the direction captures meaning, while the magnitude is less meaningful.
+
+Two other metrics you'll encounter are **Euclidean distance**, which measures the straight-line distance between two points in vector space (smaller means more similar), and **dot product**, which is computationally fast and equivalent to cosine similarity when the vectors are normalised.
+
+```python
+def euclidean_distance(vec1, vec2):
+    """Measures straight-line distance. Range: 0 to infinity."""
+    return np.linalg.norm(np.array(vec1) - np.array(vec2))
+
+def dot_product_similarity(vec1, vec2):
+    """Simple multiplication and sum."""
+    return np.dot(vec1, vec2)
+```
+
+In practice, you rarely compute these yourself. Vector databases handle similarity calculations internally. But understanding the metrics matters when you're configuring your database and interpreting results. For text embeddings, default to cosine similarity unless you have a specific reason to choose something else.
+
+::::challenge{id=m2-02-explore title="Explore Embeddings"}
+
+To build intuition for how embeddings work, try the following experiments:
+
+1. Embed a set of sentences that are semantically similar but use different words (e.g., "The car is fast" and "The automobile moves quickly"). Compute their cosine similarity. Then embed a semantically different sentence (e.g., "I enjoy reading books") and compare. How different are the similarity scores?
+
+2. Embed the same word in two different contexts (e.g., "I deposited money at the bank" and "I sat on the river bank"). Are the embeddings different? How different?
+
+3. Embed a short sentence and a long paragraph that discuss the same topic. How does length affect the similarity?
+
+```python
+import openai
+import numpy as np
+import os
+
+openai.api_key = os.getenv("OPENAI_API_KEY")
+
+def get_embedding(text):
+    response = openai.Embedding.create(
+        model="text-embedding-3-small",
+        input=text
+    )
+    return response['data'][0]['embedding']
+
+def cosine_sim(a, b):
+    return np.dot(a, b) / (np.linalg.norm(a) * np.linalg.norm(b))
+
+# Experiment 1: Semantic similarity with different words
+emb1 = get_embedding("The car is fast")
+emb2 = get_embedding("The automobile moves quickly")
+emb3 = get_embedding("I enjoy reading books")
+
+print(f"Similar meaning, different words: {cosine_sim(emb1, emb2):.3f}")
+print(f"Different meaning: {cosine_sim(emb1, emb3):.3f}")
+
+# Try your own experiments with contexts and lengths...
+```
+
+These experiments will give you a concrete feel for what embeddings capture and where they might surprise you. This intuition is valuable when debugging retrieval quality later.
+::::
+
+## Hands-on practical
+
+Work through the accompanying notebook: [`module_2/02-vector-embeddings.ipynb`](https://github.com/OxfordCompetencyCenters/aicc_chatbot_modules/blob/main/module_2/02-vector-embeddings.ipynb). It walks through creating embeddings, computing cosine similarity, contextual meaning for the same word in different sentences, and how length affects similarity.

--- a/technology_and_tooling/chatbot_development/m2-03-document-processing-and-chunking.md
+++ b/technology_and_tooling/chatbot_development/m2-03-document-processing-and-chunking.md
@@ -1,0 +1,287 @@
+---
+name: Document Processing and Chunking
+dependsOn:
+  - technology_and_tooling.chatbot_development.m2-02-vector-embeddings
+tags: [chatbots, rag, chunking]
+learningOutcomes:
+  - Explain why documents must be chunked before embedding.
+  - Implement fixed-size, semantic, and recursive chunking strategies.
+  - Use chunk overlap to preserve context across boundaries.
+  - Enrich chunks with metadata for filtering and citation.
+  - Build a complete document processing pipeline.
+attribution:
+  - citation: >
+      Oxford AI Competency Centre (2026). Chatbot Development Course.
+    url: https://github.com/OxfordCompetencyCenters/aicc_chatbot_modules
+    license: CC-BY-4.0
+---
+
+You now know how to convert text into vector embeddings. But before you can embed your documents, you need to decide how to break them into pieces. This step — called chunking — has an outsized impact on retrieval quality. Get it right, and your chatbot finds exactly the information it needs. Get it wrong, and it returns irrelevant or fragmented results no matter how good your embedding model is.
+
+## Why Chunking Matters
+
+You might wonder: why not just embed each document as a whole? There are three reasons.
+
+First, embeddings work best on focused, coherent text. When you embed a 100-page PDF as a single vector, that vector tries to represent the average meaning of everything in the document. It captures the broad topic but loses all the fine-grained detail. A search for "how to configure email notifications" would match a document about your product's settings, but wouldn't be able to pinpoint the specific paragraph about email notifications versus the one about Slack integrations.
+
+Second, LLMs have context windows. Even if you could retrieve a relevant 100-page document, you can't fit it into a single prompt alongside the system message, conversation history, and instructions. You need to retrieve only the relevant portions — which means you need to have broken the document into portions that can be retrieved independently.
+
+Third, precision matters for user trust. If your chatbot says "According to the documentation..." and then cites an entire 50-page manual, that's not useful. If it cites a specific 200-word passage that directly answers the question, that's credible and verifiable.
+
+The trade-off in chunking is between chunks that are too large (diluted semantics, wasted context window space) and chunks that are too small (fragmented information, lost context). A chunk size of 200–500 tokens is typical for most RAG applications, but the right size depends on your documents and your use case.
+
+## Chunking Strategies
+
+There are three main approaches to chunking, each with different strengths.
+
+### Fixed-Size Chunking
+
+The simplest approach is to split the text into chunks of a fixed number of characters or tokens, regardless of where sentences or paragraphs fall:
+
+```python
+def fixed_size_chunking(text, chunk_size=500, overlap=50):
+    """Split text into fixed-size chunks with overlap."""
+    chunks = []
+    start = 0
+    while start < len(text):
+        end = start + chunk_size
+        chunks.append(text[start:end])
+        start += chunk_size - overlap
+    return chunks
+```
+
+This is fast and produces consistent chunk sizes, which is convenient for token budgeting. The downside is that it breaks text at arbitrary positions — potentially in the middle of a sentence, or even in the middle of a word. A chunk that starts with "...increased by" and another that starts with "15% in Q3 2023" are both incomplete. Neither captures the full meaning on its own.
+
+### Semantic Chunking
+
+Semantic chunking splits on natural text boundaries — paragraphs, sections, or sentences:
+
+```python
+def semantic_chunking(text):
+    """Split on paragraph boundaries."""
+    chunks = text.split('\n\n')
+    return [chunk.strip() for chunk in chunks if chunk.strip()]
+```
+
+This respects the structure of the document, so each chunk is more likely to be a coherent, self-contained unit of information. The downside is that chunk sizes can vary wildly. A short paragraph might produce a 20-token chunk, while a long section might produce a 2,000-token chunk. Inconsistent sizes complicate token budgeting and can lead to some chunks being too small to be meaningful and others too large to be focused.
+
+### Recursive Chunking
+
+Recursive chunking — implemented in LangChain's `RecursiveCharacterTextSplitter` — combines the strengths of both approaches. It tries to split on paragraph boundaries first. If the resulting chunks are still too large, it falls back to sentence boundaries. If those are still too large, it falls back to word boundaries. This respects natural structure while keeping chunks within a target size:
+
+```python
+from langchain.text_splitter import RecursiveCharacterTextSplitter
+
+splitter = RecursiveCharacterTextSplitter(
+    chunk_size=500,
+    chunk_overlap=50,
+    separators=["\n\n", "\n", ". ", " ", ""]
+)
+chunks = splitter.split_text(text)
+```
+
+The `separators` list defines the priority order for splitting. The splitter tries `"\n\n"` (paragraph breaks) first, then `"\n"` (line breaks), then `". "` (sentence ends), then `" "` (word boundaries), and finally `""` (individual characters) as a last resort. This produces chunks that are both coherent and consistently sized.
+
+For most RAG applications, recursive chunking is the best default choice. It's what you should start with unless you have a specific reason to use something else.
+
+## Chunk Overlap
+
+When you split a document into chunks, information at the boundaries can be lost. Consider a passage where one sentence sets up context and the next sentence provides the key fact. If the chunk boundary falls between those two sentences, neither chunk captures the complete picture.
+
+Chunk overlap solves this by making adjacent chunks share some content:
+
+```
+Without overlap:
+  Chunk 1: [...important information starts here]
+  Chunk 2: [continues here with critical context...]
+  → If a query matches chunk 2, the setup from chunk 1 is missing
+
+With overlap:
+  Chunk 1: [...important information starts here...]
+  Chunk 2: [...starts here continues here with critical context...]
+  → Both chunks have enough context to be meaningful
+```
+
+A typical overlap is 10–20% of the chunk size. For 500-token chunks, that means 50–100 tokens of overlap. More overlap means more redundancy (you're storing and embedding the same text multiple times), but better context preservation at boundaries.
+
+Here's how to configure overlap with LangChain:
+
+```python
+from langchain.text_splitter import RecursiveCharacterTextSplitter
+
+splitter = RecursiveCharacterTextSplitter(
+    chunk_size=1000,
+    chunk_overlap=200,  # 20% overlap
+    length_function=len,
+)
+
+text = open("document.txt").read()
+chunks = splitter.split_text(text)
+
+print(f"Created {len(chunks)} chunks")
+for i, chunk in enumerate(chunks[:3]):
+    print(f"\nChunk {i}: {chunk[:100]}...")
+```
+
+## Enriching Chunks with Metadata
+
+Raw text chunks are useful, but chunks enriched with metadata are far more powerful. Metadata lets you filter search results ("only search documents from 2024"), track provenance for citations ("this answer came from page 5 of the user guide"), and implement hybrid search strategies.
+
+When you process a document, attach metadata to each chunk:
+
+```python
+chunk_with_metadata = {
+    "text": "Python is a versatile programming language...",
+    "metadata": {
+        "source": "python_guide.pdf",
+        "page": 5,
+        "section": "Introduction",
+        "author": "John Doe",
+        "date": "2024-01-15",
+        "doc_type": "tutorial",
+        "language": "en"
+    }
+}
+```
+
+At retrieval time, you can combine vector search with metadata filters:
+
+```python
+results = vector_db.search(
+    query="How do I use Python lists?",
+    filter={"doc_type": "tutorial", "language": "en"},
+    top_k=5
+)
+```
+
+This is particularly valuable in production. A customer support chatbot might filter by product version so it only retrieves documentation relevant to the customer's setup. A legal assistant might filter by jurisdiction and date. An internal knowledge base might filter by department.
+
+Metadata is also essential for citations. When your chatbot cites its sources, it needs to know which file, which page, and which section each chunk came from:
+
+```python
+def generate_response_with_citations(query, retrieved_chunks):
+    context = ""
+    sources = []
+
+    for chunk in retrieved_chunks:
+        context += chunk["text"] + "\n"
+        sources.append(f"{chunk['source']} (page {chunk['page']})")
+
+    prompt = f"""Context: {context}
+
+    Question: {query}
+
+    Answer the question using the context above. Cite your sources."""
+
+    response = llm.generate(prompt)
+    return response, sources
+```
+
+## Building a Complete Document Processing Pipeline
+
+Putting it all together, here is a complete pipeline that takes a file, cleans the text, chunks it, generates embeddings, and attaches metadata:
+
+```python
+import openai
+from langchain.text_splitter import RecursiveCharacterTextSplitter
+
+def process_document(file_path, metadata=None):
+    """Complete pipeline: load → clean → chunk → embed."""
+
+    # 1. Load the document
+    with open(file_path, 'r') as f:
+        text = f.read()
+
+    # 2. Clean the text
+    text = text.replace('\n\n\n', '\n\n')
+    text = text.strip()
+
+    # 3. Chunk with overlap
+    splitter = RecursiveCharacterTextSplitter(
+        chunk_size=1000,
+        chunk_overlap=200,
+        separators=["\n\n", "\n", ". ", " ", ""]
+    )
+    chunks = splitter.split_text(text)
+
+    # 4. Generate embeddings in batches
+    embeddings = []
+    batch_size = 100
+
+    for i in range(0, len(chunks), batch_size):
+        batch = chunks[i:i+batch_size]
+        response = openai.Embedding.create(
+            model="text-embedding-3-small",
+            input=batch
+        )
+        batch_embeddings = [item['embedding'] for item in response['data']]
+        embeddings.extend(batch_embeddings)
+
+    # 5. Combine chunks, embeddings, and metadata
+    processed_chunks = []
+    for idx, (chunk, embedding) in enumerate(zip(chunks, embeddings)):
+        processed_chunks.append({
+            "id": f"{file_path}_{idx}",
+            "text": chunk,
+            "embedding": embedding,
+            "metadata": {
+                "source": file_path,
+                "chunk_index": idx,
+                **(metadata or {})
+            }
+        })
+
+    return processed_chunks
+
+# Usage
+chunks = process_document(
+    "docs/user_guide.txt",
+    metadata={"doc_type": "guide", "version": "2.0"}
+)
+print(f"Processed {len(chunks)} chunks")
+```
+
+This pipeline is your indexing step — the offline phase of RAG. You run it once for each document (or periodically when documents are updated). The output is a list of chunks, each with its text, its embedding, and its metadata, ready to be stored in a vector database.
+
+In production, you'd add error handling, progress logging, and support for different file formats (PDF, HTML, DOCX). You might also add a deduplication step to avoid indexing the same content twice. But this basic pipeline captures the essential structure that every RAG indexing system follows.
+
+::::challenge{id=m2-03-compare title="Compare Chunking Strategies"}
+
+Process the same document using three different chunking strategies and compare the results.
+
+```python
+from langchain.text_splitter import RecursiveCharacterTextSplitter
+
+# Load a sample document (use any text file you have)
+with open("sample_document.txt", "r") as f:
+    text = f.read()
+
+# Strategy 1: Small chunks, no overlap
+splitter_small = RecursiveCharacterTextSplitter(chunk_size=200, chunk_overlap=0)
+chunks_small = splitter_small.split_text(text)
+
+# Strategy 2: Medium chunks with overlap
+splitter_medium = RecursiveCharacterTextSplitter(chunk_size=500, chunk_overlap=50)
+chunks_medium = splitter_medium.split_text(text)
+
+# Strategy 3: Large chunks with overlap
+splitter_large = RecursiveCharacterTextSplitter(chunk_size=1000, chunk_overlap=200)
+chunks_large = splitter_large.split_text(text)
+
+print(f"Small chunks: {len(chunks_small)} chunks")
+print(f"Medium chunks: {len(chunks_medium)} chunks")
+print(f"Large chunks: {len(chunks_large)} chunks")
+
+# Inspect the first few chunks from each strategy
+for name, chunks in [("Small", chunks_small), ("Medium", chunks_medium), ("Large", chunks_large)]:
+    print(f"\n--- {name} chunks (first 2) ---")
+    for i, chunk in enumerate(chunks[:2]):
+        print(f"  Chunk {i} ({len(chunk)} chars): {chunk[:100]}...")
+```
+
+Look at the chunks each strategy produces. Are the small chunks coherent on their own, or do they feel fragmented? Are the large chunks too broad, mixing multiple topics? Which strategy produces chunks that feel like self-contained units of information? The answers will depend on your specific document, which is why experimenting with your actual data is so important.
+::::
+
+## Hands-on practical
+
+Work through the accompanying notebook: [`module_2/03-document-processing-and-chunking.ipynb`](https://github.com/OxfordCompetencyCenters/aicc_chatbot_modules/blob/main/module_2/03-document-processing-and-chunking.ipynb). It walks through fixed-size chunking, recursive splitting on natural boundaries, and a complete chunk-plus-metadata-plus-embed pipeline.

--- a/technology_and_tooling/chatbot_development/m2-03-document-processing-and-chunking.md
+++ b/technology_and_tooling/chatbot_development/m2-03-document-processing-and-chunking.md
@@ -13,6 +13,7 @@ attribution:
   - citation: >
       Oxford AI Competency Centre (2026). Chatbot Development Course.
     url: https://github.com/OxfordCompetencyCenters/aicc_chatbot_modules
+    image: https://github.com/OxfordCompetencyCenters.png
     license: CC-BY-4.0
 ---
 

--- a/technology_and_tooling/chatbot_development/m2-03-document-processing-and-chunking.md
+++ b/technology_and_tooling/chatbot_development/m2-03-document-processing-and-chunking.md
@@ -1,7 +1,7 @@
 ---
 name: Document Processing and Chunking
 dependsOn:
-  - technology_and_tooling.chatbot_development.m2-02-vector-embeddings
+  - technology_and_tooling.chatbot_development.m2-01-the-rag-paradigm
 tags: [chatbots, rag, chunking]
 learningOutcomes:
   - Explain why documents must be chunked before embedding.

--- a/technology_and_tooling/chatbot_development/m2-04-vector-databases.md
+++ b/technology_and_tooling/chatbot_development/m2-04-vector-databases.md
@@ -1,0 +1,268 @@
+---
+name: Vector Databases
+dependsOn:
+  - technology_and_tooling.chatbot_development.m2-03-document-processing-and-chunking
+tags: [chatbots, rag, databases]
+learningOutcomes:
+  - Explain why vector databases are needed for RAG at scale.
+  - Set up ChromaDB and perform basic operations (add, query, filter).
+  - Integrate ChromaDB with OpenAI embeddings for semantic search.
+  - Understand the landscape of vector database options for production use.
+attribution:
+  - citation: >
+      Oxford AI Competency Centre (2026). Chatbot Development Course.
+    url: https://github.com/OxfordCompetencyCenters/aicc_chatbot_modules
+    license: CC-BY-4.0
+---
+
+You now have chunks with embeddings. The next question is: where do you store them, and how do you search through them efficiently? For a handful of documents, you could compute cosine similarity against every chunk on every query. But for thousands or millions of chunks, that brute-force approach is far too slow. Vector databases solve this problem with specialised indexing algorithms that make similarity search fast even at massive scale.
+
+## Why Vector Databases?
+
+A vector database is a specialised storage system designed for storing, indexing, and searching vector embeddings. Unlike traditional databases that search by exact matches or range queries on structured fields, vector databases find the nearest neighbours to a query vector in high-dimensional space.
+
+The core challenge is speed. If you have a million document chunks, each represented by a 1,536-dimensional vector, a brute-force search computes 1 million cosine similarities for every query. That's feasible but slow — and it gets worse as your corpus grows. Vector databases use approximate nearest neighbour (ANN) algorithms, such as HNSW (Hierarchical Navigable Small World graphs), to find similar vectors in logarithmic time rather than linear time. The results are slightly approximate — you might miss the absolute best match occasionally — but the speed improvement is dramatic, and for RAG purposes the approximation is more than good enough.
+
+Beyond fast search, vector databases provide metadata filtering (combine vector similarity with structured filters), CRUD operations (add, update, and delete vectors as your corpus changes), persistence (data survives restarts), and scalability (handle millions or billions of vectors).
+
+The landscape of vector databases has grown rapidly. Here are the main options:
+
+| Database | Type | Best For |
+|----------|------|----------|
+| ChromaDB | Local/Embedded | Development, prototyping, small scale |
+| Pinecone | Managed Cloud | Production at scale |
+| Weaviate | Self-hosted/Cloud | Flexibility, open-source |
+| Qdrant | Self-hosted/Cloud | High performance |
+| Milvus | Self-hosted | Large scale, open-source |
+
+For learning and development, ChromaDB is the ideal choice. It's free, runs locally with no infrastructure to manage, and has a clean, intuitive API. For production systems that need to handle millions of users and billions of vectors, a managed service like Pinecone removes the operational burden.
+
+## Getting Started with ChromaDB
+
+Install ChromaDB with pip:
+
+```bash
+pip install chromadb
+```
+
+ChromaDB organises data into **collections**, which are analogous to tables in a relational database. Each collection stores vectors alongside their original text and metadata. Here's a basic example that creates a collection, adds some documents, and searches:
+
+```python
+import chromadb
+
+# Initialize a persistent client (data saved to disk)
+client = chromadb.PersistentClient(path="./chroma_db")
+
+# Create a collection
+collection = client.create_collection(
+    name="my_documents",
+    metadata={"description": "My document embeddings"}
+)
+
+# Add documents with pre-computed embeddings
+collection.add(
+    ids=["doc1", "doc2", "doc3"],
+    embeddings=[
+        [0.1, 0.2, 0.3],
+        [0.2, 0.3, 0.4],
+        [0.5, 0.6, 0.7]
+    ],
+    documents=[
+        "This is document 1",
+        "This is document 2",
+        "This is document 3"
+    ],
+    metadatas=[
+        {"source": "file1.txt", "page": 1},
+        {"source": "file1.txt", "page": 2},
+        {"source": "file2.txt", "page": 1}
+    ]
+)
+
+# Search for similar documents
+results = collection.query(
+    query_embeddings=[[0.15, 0.25, 0.35]],
+    n_results=2
+)
+
+print("Top results:", results['documents'])
+print("Metadata:", results['metadatas'])
+print("Distances:", results['distances'])
+```
+
+A few things to note. The `PersistentClient` saves data to disk at the specified path, so your data survives when you restart your script. Each document gets a unique ID — if you try to add a document with an ID that already exists, ChromaDB will raise an error (use `upsert` instead if you want to update). The `documents` field stores the original text alongside the embedding, which is crucial for RAG since you need the actual text to include in the LLM prompt. And the `metadatas` field accepts any dictionary of JSON-serializable values.
+
+If you want to avoid re-creating a collection that already exists, use `get_or_create_collection` instead of `create_collection`:
+
+```python
+collection = client.get_or_create_collection(name="my_documents")
+```
+
+## Integrating ChromaDB with OpenAI Embeddings
+
+In practice, you won't pre-compute embeddings by hand. You'll generate them from the OpenAI API and store them in ChromaDB. Here's a complete integration that provides two essential operations: indexing documents and searching for relevant ones.
+
+```python
+import chromadb
+import openai
+import os
+
+openai.api_key = os.getenv("OPENAI_API_KEY")
+
+client = chromadb.PersistentClient(path="./chroma_db")
+collection = client.get_or_create_collection(name="documents")
+
+def add_documents(documents, metadatas=None):
+    """Embed documents and add them to ChromaDB."""
+    response = openai.Embedding.create(
+        model="text-embedding-3-small",
+        input=documents
+    )
+    embeddings = [item['embedding'] for item in response['data']]
+
+    ids = [f"doc_{i}" for i in range(len(documents))]
+
+    collection.add(
+        ids=ids,
+        embeddings=embeddings,
+        documents=documents,
+        metadatas=metadatas or [{}] * len(documents)
+    )
+    print(f"Added {len(documents)} documents")
+
+def search_documents(query, top_k=3):
+    """Embed a query and search for similar documents."""
+    response = openai.Embedding.create(
+        model="text-embedding-3-small",
+        input=query
+    )
+    query_embedding = response['data'][0]['embedding']
+
+    results = collection.query(
+        query_embeddings=[query_embedding],
+        n_results=top_k
+    )
+    return results
+
+# Index some documents
+docs = [
+    "Python is a high-level programming language.",
+    "JavaScript is used for web development.",
+    "Machine learning is a subset of artificial intelligence."
+]
+add_documents(docs)
+
+# Search
+results = search_documents("What is Python?")
+print("Top result:", results['documents'][0])
+```
+
+This is the core of a RAG retrieval system. You embed documents once during indexing, then embed each user query at search time and find the most similar stored documents. ChromaDB handles the similarity calculation internally using cosine distance by default.
+
+## Choosing a Similarity Metric
+
+ChromaDB supports three similarity metrics, configured at collection creation time:
+
+```python
+# Cosine similarity (default) — measures angle between vectors
+collection = client.create_collection(
+    name="docs_cosine",
+    metadata={"hnsw:space": "cosine"}
+)
+
+# Euclidean distance (L2) — measures straight-line distance
+collection = client.create_collection(
+    name="docs_l2",
+    metadata={"hnsw:space": "l2"}
+)
+
+# Inner product (dot product) — fast, best with normalized embeddings
+collection = client.create_collection(
+    name="docs_ip",
+    metadata={"hnsw:space": "ip"}
+)
+```
+
+For text embeddings from OpenAI, cosine similarity is the right default. It focuses on the direction of vectors (which captures meaning) rather than their magnitude. The differences between metrics are usually minor for well-trained embeddings, so don't spend much time optimising this unless you've identified it as a bottleneck in retrieval quality.
+
+## A Note on Production: Pinecone and Other Managed Services
+
+ChromaDB is excellent for development and small-scale applications, but production systems with millions of users and billions of vectors typically need a managed service. Pinecone is the most widely used option. It handles infrastructure, scaling, backups, and monitoring so you can focus on your application logic.
+
+The API is conceptually similar to ChromaDB:
+
+```python
+import pinecone
+
+pinecone.init(api_key="your-api-key", environment="us-west1-gcp")
+
+pinecone.create_index(
+    name="documents",
+    dimension=1536,
+    metric="cosine"
+)
+
+index = pinecone.Index("documents")
+
+# Upsert vectors
+index.upsert(vectors=[
+    ("doc1", [0.1, 0.2, ...], {"text": "Document 1", "source": "file1.txt"}),
+    ("doc2", [0.3, 0.4, ...], {"text": "Document 2", "source": "file2.txt"})
+])
+
+# Query
+results = index.query(vector=[0.15, 0.25, ...], top_k=3, include_metadata=True)
+```
+
+The core operations — upsert vectors, query by similarity, filter by metadata — are the same across all vector databases. The differences are in scaling, pricing, and operational features. For this course, we'll use ChromaDB throughout. If you later move to Pinecone, Weaviate, or Qdrant, the concepts transfer directly; only the API details change.
+
+::::challenge{id=m2-04-semantic-search title="Build a Semantic Search System"}
+
+Put the pieces together by building a semantic search system from scratch. Create a ChromaDB collection, index a set of documents with OpenAI embeddings, and test the search with various queries.
+
+```python
+import chromadb
+import openai
+import os
+
+openai.api_key = os.getenv("OPENAI_API_KEY")
+client = chromadb.PersistentClient(path="./exercise_chroma_db")
+collection = client.get_or_create_collection("exercise_docs")
+
+# 1. Prepare a set of documents about different topics
+documents = [
+    "Python was created by Guido van Rossum and first released in 1991.",
+    "Lists in Python are ordered, mutable sequences that can hold any type of object.",
+    "A Python dictionary stores key-value pairs and provides fast lookup by key.",
+    "Functions in Python are defined using the def keyword followed by the function name.",
+    "Classes in Python support inheritance, allowing child classes to extend parent classes.",
+    "Exception handling in Python uses try, except, and finally blocks.",
+]
+
+metadatas = [
+    {"source": "python_history.txt", "topic": "history"},
+    {"source": "python_collections.txt", "topic": "data structures"},
+    {"source": "python_collections.txt", "topic": "data structures"},
+    {"source": "python_functions.txt", "topic": "functions"},
+    {"source": "python_oop.txt", "topic": "classes"},
+    {"source": "python_errors.txt", "topic": "error handling"},
+]
+
+# 2. TODO: Embed and index these documents
+
+# 3. TODO: Search with these queries and verify the results make sense:
+test_queries = [
+    "Who created Python?",
+    "How do I store key-value data?",
+    "How do I handle errors in my code?",
+]
+
+# 4. TODO: Try a query with metadata filtering (e.g., only "data structures" topic)
+```
+
+After implementing the basic search, experiment with queries that use different phrasing from the documents. Does "error handling" match the document about exceptions? Does "inventor of Python" match the document about Guido van Rossum? Exploring these edge cases builds your intuition for how semantic search behaves in practice.
+::::
+
+## Hands-on practical
+
+Work through the accompanying notebook: [`module_2/04-vector-databases.ipynb`](https://github.com/OxfordCompetencyCenters/aicc_chatbot_modules/blob/main/module_2/04-vector-databases.ipynb). It walks through creating a persistent ChromaDB collection, adding documents with OpenAI embeddings, performing similarity search, and applying metadata filters.

--- a/technology_and_tooling/chatbot_development/m2-04-vector-databases.md
+++ b/technology_and_tooling/chatbot_development/m2-04-vector-databases.md
@@ -12,6 +12,7 @@ attribution:
   - citation: >
       Oxford AI Competency Centre (2026). Chatbot Development Course.
     url: https://github.com/OxfordCompetencyCenters/aicc_chatbot_modules
+    image: https://github.com/OxfordCompetencyCenters.png
     license: CC-BY-4.0
 ---
 

--- a/technology_and_tooling/chatbot_development/m2-04-vector-databases.md
+++ b/technology_and_tooling/chatbot_development/m2-04-vector-databases.md
@@ -1,7 +1,7 @@
 ---
 name: Vector Databases
 dependsOn:
-  - technology_and_tooling.chatbot_development.m2-03-document-processing-and-chunking
+  - technology_and_tooling.chatbot_development.m2-01-the-rag-paradigm
 tags: [chatbots, rag, databases]
 learningOutcomes:
   - Explain why vector databases are needed for RAG at scale.

--- a/technology_and_tooling/chatbot_development/m2-05-building-a-rag-chatbot.md
+++ b/technology_and_tooling/chatbot_development/m2-05-building-a-rag-chatbot.md
@@ -12,6 +12,7 @@ attribution:
   - citation: >
       Oxford AI Competency Centre (2026). Chatbot Development Course.
     url: https://github.com/OxfordCompetencyCenters/aicc_chatbot_modules
+    image: https://github.com/OxfordCompetencyCenters.png
     license: CC-BY-4.0
 ---
 

--- a/technology_and_tooling/chatbot_development/m2-05-building-a-rag-chatbot.md
+++ b/technology_and_tooling/chatbot_development/m2-05-building-a-rag-chatbot.md
@@ -1,7 +1,7 @@
 ---
 name: Building a RAG Chatbot
 dependsOn:
-  - technology_and_tooling.chatbot_development.m2-04-vector-databases
+  - technology_and_tooling.chatbot_development.m2-01-the-rag-paradigm
 tags: [chatbots, rag, python]
 learningOutcomes:
   - Build a complete RAG chatbot that retrieves documents and generates grounded responses.

--- a/technology_and_tooling/chatbot_development/m2-05-building-a-rag-chatbot.md
+++ b/technology_and_tooling/chatbot_development/m2-05-building-a-rag-chatbot.md
@@ -1,0 +1,402 @@
+---
+name: Building a RAG Chatbot
+dependsOn:
+  - technology_and_tooling.chatbot_development.m2-04-vector-databases
+tags: [chatbots, rag, python]
+learningOutcomes:
+  - Build a complete RAG chatbot that retrieves documents and generates grounded responses.
+  - Write effective RAG prompts that constrain the LLM to use retrieved context.
+  - Implement source citation in chatbot responses.
+  - Manage the context window when combining retrieved documents with conversation history.
+attribution:
+  - citation: >
+      Oxford AI Competency Centre (2026). Chatbot Development Course.
+    url: https://github.com/OxfordCompetencyCenters/aicc_chatbot_modules
+    license: CC-BY-4.0
+---
+
+You now have all the building blocks: embeddings for semantic representation, chunking for document preparation, and a vector database for storage and search. In this section, we assemble them into a complete RAG chatbot — a system that answers user questions by retrieving relevant documents and generating responses grounded in those documents.
+
+## The Complete RAG Chatbot
+
+Here is a full implementation that ties together everything from this module. The `RAGChatbot` class handles document indexing, retrieval, and response generation:
+
+```python
+import chromadb
+import openai
+import os
+
+openai.api_key = os.getenv("OPENAI_API_KEY")
+
+class RAGChatbot:
+    def __init__(self, collection_name="rag_docs"):
+        self.client = chromadb.PersistentClient(path="./chroma_db")
+        self.collection = self.client.get_or_create_collection(collection_name)
+
+    def add_documents(self, documents, metadatas=None):
+        """Index documents for retrieval."""
+        response = openai.Embedding.create(
+            model="text-embedding-3-small",
+            input=documents
+        )
+        embeddings = [item['embedding'] for item in response['data']]
+
+        ids = [f"doc_{i}" for i in range(len(documents))]
+        self.collection.add(
+            ids=ids,
+            embeddings=embeddings,
+            documents=documents,
+            metadatas=metadatas or [{}] * len(documents)
+        )
+
+    def retrieve(self, query, top_k=3):
+        """Retrieve the most relevant documents for a query."""
+        response = openai.Embedding.create(
+            model="text-embedding-3-small",
+            input=query
+        )
+        query_embedding = response['data'][0]['embedding']
+
+        results = self.collection.query(
+            query_embeddings=[query_embedding],
+            n_results=top_k
+        )
+        return results['documents'][0], results['metadatas'][0]
+
+    def chat(self, user_query, top_k=3):
+        """Answer a query using RAG: retrieve, then generate."""
+        # 1. Retrieve relevant documents
+        documents, metadatas = self.retrieve(user_query, top_k)
+
+        # 2. Build context from retrieved documents
+        context = "\n\n".join([
+            f"Document {i+1}: {doc}"
+            for i, doc in enumerate(documents)
+        ])
+
+        # 3. Build the prompt
+        prompt = f"""You are a helpful assistant. Answer the user's question
+using ONLY the information provided in the context below.
+
+Context:
+{context}
+
+Question: {user_query}
+
+Instructions:
+- Base your answer strictly on the provided context.
+- If the context doesn't contain enough information, say so.
+- Cite which document(s) you drew from when possible.
+
+Answer:"""
+
+        # 4. Generate the response
+        response = openai.ChatCompletion.create(
+            model="gpt-3.5-turbo",
+            messages=[
+                {"role": "system", "content": "You are a helpful assistant that answers questions based on provided context."},
+                {"role": "user", "content": prompt}
+            ],
+            temperature=0.3
+        )
+
+        answer = response.choices[0].message.content
+        sources = [meta.get('source', 'Unknown') for meta in metadatas]
+
+        return {
+            "answer": answer,
+            "sources": sources,
+            "retrieved_docs": documents
+        }
+```
+
+The flow is straightforward: the user asks a question, we embed it and search the vector database for similar chunks, we inject those chunks into the prompt as context, and the LLM generates a response based on that context. The low temperature (0.3) is deliberate — for factual questions grounded in documents, you want consistent, focused answers rather than creative variations.
+
+Here's how to use it:
+
+```python
+bot = RAGChatbot()
+
+# Index some documents
+docs = [
+    "Python was created by Guido van Rossum and first released in 1991.",
+    "Python is known for its simple and readable syntax.",
+    "Python is widely used in web development, data science, and AI."
+]
+bot.add_documents(docs, metadatas=[
+    {"source": "python_history.txt"},
+    {"source": "python_features.txt"},
+    {"source": "python_applications.txt"}
+])
+
+# Query
+result = bot.chat("When was Python created?")
+print("Answer:", result['answer'])
+print("Sources:", result['sources'])
+```
+
+The chatbot retrieves the relevant document about Python's history, includes it as context, and the LLM generates an answer grounded in that specific document. The response includes source information so the user can verify the answer.
+
+## Writing Effective RAG Prompts
+
+The prompt you use when combining retrieved documents with the user's question has an enormous impact on response quality. The most important instruction is to tell the LLM to answer **only** from the provided context. Without this constraint, the model may draw on its training data and produce answers that sound authoritative but aren't grounded in your documents — defeating the purpose of RAG.
+
+A basic prompt might look like this:
+
+```python
+prompt = f"""Answer based on the context below.
+
+Context: {context}
+
+Question: {query}"""
+```
+
+This works but lacks guardrails. An enhanced prompt adds explicit instructions for edge cases:
+
+```python
+prompt = f"""You are a knowledgeable assistant. Answer the user's question
+using ONLY the information provided in the context below.
+
+Context:
+{context}
+
+Question: {query}
+
+Instructions:
+- Base your answer strictly on the provided context
+- If the context doesn't contain enough information to answer fully, say
+  "I don't have enough information to answer that"
+- Cite specific details from the context when possible
+- Be concise but complete
+- If multiple documents provide relevant information, synthesize them"""
+```
+
+The "I don't have enough information" instruction is critical. Without it, when retrieval fails to find relevant documents (which will happen), the LLM fills the gap with its training data. That's exactly the hallucination problem RAG is supposed to solve. By explicitly instructing the model to admit uncertainty, you preserve the trustworthiness of the system.
+
+For complex questions that require reasoning across multiple retrieved documents, a chain-of-thought approach can improve accuracy:
+
+```python
+prompt = f"""Context:
+{context}
+
+Question: {query}
+
+Think through this step-by-step:
+1. What information from the context is relevant to this question?
+2. Is there enough information to answer fully?
+3. What is the most accurate answer based on the context?
+
+Answer:"""
+```
+
+This encourages the model to reason explicitly about which parts of the context are relevant before composing its answer, which tends to produce more accurate and well-supported responses.
+
+## Managing Context with Retrieved Documents
+
+When you combine RAG with a stateful chatbot (which most production systems are), you need to fit three things into the context window: the system prompt, the conversation history, and the retrieved documents. Token budget management becomes even more important than in Module 1, because retrieved context can be substantial.
+
+Here's an approach that limits the total context by selecting only as many retrieved documents as will fit:
+
+```python
+import tiktoken
+
+def chat_with_token_limit(self, user_question, top_k=5, max_context_tokens=2000):
+    """RAG with context window management."""
+    enc = tiktoken.encoding_for_model("gpt-3.5-turbo")
+
+    # Retrieve more documents than we might need
+    documents, metadatas = self.retrieve(user_question, top_k=top_k)
+
+    # Add documents until we hit the token budget
+    context_docs = []
+    current_tokens = 0
+
+    for doc in documents:
+        doc_tokens = len(enc.encode(doc))
+        if current_tokens + doc_tokens < max_context_tokens:
+            context_docs.append(doc)
+            current_tokens += doc_tokens
+        else:
+            break
+
+    # Build the prompt with the trimmed context
+    context = "\n\n".join(context_docs)
+    # ... continue with prompt construction and LLM call
+```
+
+The strategy is to retrieve more documents than you expect to use (`top_k=5`), then include them in order of relevance until you run out of token budget. Since the vector database returns results sorted by similarity, the most relevant documents are included first and less relevant ones are dropped if space is tight.
+
+In Module 4, we'll explore more sophisticated approaches to balancing conversation history with retrieved context. For now, the key principle is: always be aware of how many tokens your retrieved context consumes, and set explicit budgets.
+
+::::challenge{id=m2-05-ex1 title="Process and Index Documents"}
+
+Build the document processing pipeline for a set of sample documents. Load each file, chunk it, generate embeddings, and store everything in ChromaDB.
+
+```python
+import openai
+from langchain.text_splitter import RecursiveCharacterTextSplitter
+import os
+
+openai.api_key = os.getenv("OPENAI_API_KEY")
+
+def process_documents(file_paths, chunk_size=1000, overlap=200):
+    """
+    Process multiple documents: load, chunk, embed, and return
+    structured data ready for indexing.
+    """
+    all_chunks = []
+
+    for file_path in file_paths:
+        # TODO: Read the file
+        # TODO: Chunk the text using RecursiveCharacterTextSplitter
+        # TODO: Generate embeddings for each chunk (batch for efficiency)
+        # TODO: Attach metadata (source file, chunk index)
+        pass
+
+    return all_chunks
+
+# Test with sample documents
+file_paths = [
+    "./sample_docs/python_basics.txt",
+    "./sample_docs/python_functions.txt",
+    "./sample_docs/python_classes.txt"
+]
+
+chunks = process_documents(file_paths)
+print(f"Processed {len(chunks)} chunks")
+```
+
+After implementing the basic pipeline, test with different chunk sizes (500, 1000, 2000) and observe how the number of chunks and their coherence change.
+::::
+
+::::challenge{id=m2-05-ex2 title="Index and Search with ChromaDB"}
+
+Take the processed chunks from Exercise 1 and build a search system.
+
+```python
+import chromadb
+
+client = chromadb.PersistentClient(path="./lab_chroma_db")
+collection = client.get_or_create_collection("python_docs")
+
+def index_chunks(chunks):
+    """Add processed chunks to ChromaDB."""
+    # TODO: Extract ids, embeddings, documents, and metadatas from chunks
+    # TODO: Add to collection
+    pass
+
+def semantic_search(query, top_k=3):
+    """Search for relevant chunks."""
+    # TODO: Embed the query
+    # TODO: Search the collection
+    # TODO: Return results with metadata
+    pass
+
+# Index your chunks
+index_chunks(chunks)
+
+# Test with queries you know the answer to
+test_queries = [
+    "How do I define a function in Python?",
+    "What are Python classes?",
+    "Explain Python data types"
+]
+
+for query in test_queries:
+    print(f"\nQuery: {query}")
+    results = semantic_search(query, top_k=2)
+    print(f"Top result: {results['documents'][0][0][:200]}...")
+```
+
+Write a simple evaluation function to check whether the right source document is retrieved for each query:
+
+```python
+def evaluate_retrieval(query, expected_source):
+    """Check if the correct document is retrieved."""
+    results = semantic_search(query, top_k=1)
+    retrieved_source = results['metadatas'][0][0]['source']
+
+    if expected_source in retrieved_source:
+        print(f"  Correct retrieval for: {query}")
+    else:
+        print(f"  Wrong retrieval for: {query}")
+        print(f"  Expected: {expected_source}, Got: {retrieved_source}")
+
+evaluate_retrieval("How do I define a function?", "python_functions.txt")
+evaluate_retrieval("What is a class?", "python_classes.txt")
+```
+::::
+
+::::challenge{id=m2-05-ex3 title="Build the Complete RAG Chatbot"}
+
+Combine retrieval with generation to build a working RAG chatbot.
+
+```python
+class PythonDocsRAG:
+    def __init__(self, collection):
+        self.collection = collection
+
+    def chat(self, user_question, top_k=3):
+        """Answer a question using RAG."""
+        # TODO: 1. Retrieve relevant documents
+        # TODO: 2. Build context from retrieved docs
+        # TODO: 3. Create a prompt that instructs the LLM to use only the context
+        # TODO: 4. Generate the response
+        # TODO: 5. Return the answer with source citations
+        pass
+
+# Test your chatbot
+rag_bot = PythonDocsRAG(collection)
+
+questions = [
+    "How do I create a list in Python?",
+    "What is the difference between a function and a method?",
+    "How do I handle exceptions in Python?",
+    "What is inheritance in Python classes?"
+]
+
+for question in questions:
+    print(f"\nQ: {question}")
+    result = rag_bot.chat(question)
+    print(f"A: {result['answer']}")
+    print(f"Sources: {', '.join(result['sources'])}")
+    print("-" * 80)
+```
+
+Test with questions where you know the answer and can verify whether the chatbot is drawing from the correct documents. Also test with a question that your documents don't cover — does the chatbot admit it doesn't have enough information, or does it hallucinate?
+::::
+
+::::challenge{id=m2-05-checkpoint title="Project Checkpoint 2: Add RAG to Your Capstone"}
+
+Building on your Module 1 capstone, add document-powered knowledge retrieval to your chatbot.
+
+Prepare a document corpus for your chosen domain — at least 10 documents. For a customer support chatbot, this might be product documentation, FAQs, and troubleshooting guides. For an educational tutor, it might be course materials and textbook excerpts. For an e-commerce assistant, it might be product catalogues and policy documents.
+
+By the end of this checkpoint, your capstone should include:
+
+- A document processing pipeline (chunking and embedding)
+- ChromaDB integration for storage and retrieval
+- A RAG-powered chat function that retrieves relevant context before generating responses
+- Source citations in responses
+- Updated documentation describing your approach
+
+Test extensively by asking questions where you know which document should be retrieved. If retrieval is poor, experiment with different chunk sizes. If answers are wrong despite correct retrieval, improve your RAG prompt.
+::::
+
+## Summary and What's Next
+
+In this module, you've built a RAG system from the ground up: embeddings that capture semantic meaning, chunking strategies that prepare documents for retrieval, a vector database for efficient search, and a chatbot that grounds its responses in retrieved documents. Your chatbot can now answer questions about your specific data, cite its sources, and admit when it doesn't have enough information.
+
+In Module 3, we'll make this RAG system significantly better. You'll learn advanced techniques like re-ranking (reordering search results for higher precision), hybrid search (combining semantic and keyword search), multi-step retrieval (breaking complex questions into sub-queries), and semantic caching (avoiding redundant API calls for similar questions). These optimisations can dramatically improve both the quality and cost-efficiency of your RAG system.
+
+## Additional Resources
+
+- [Original RAG Paper](https://arxiv.org/abs/2005.11401) — "Retrieval-Augmented Generation for Knowledge-Intensive NLP Tasks" (Lewis et al., 2020)
+- [OpenAI Embeddings Guide](https://platform.openai.com/docs/guides/embeddings) — Official documentation for the Embeddings API
+- [ChromaDB Documentation](https://docs.trychroma.com) — Full reference for ChromaDB
+- [The Illustrated Word2vec](https://jalammar.github.io/illustrated-word2vec/) — Visual guide to understanding word embeddings
+- [Embedding Projector](https://projector.tensorflow.org) — Interactive tool for visualising embeddings in 3D
+
+## Hands-on practical
+
+Work through the accompanying notebook: [`module_2/05-building-a-rag-chatbot.ipynb`](https://github.com/OxfordCompetencyCenters/aicc_chatbot_modules/blob/main/module_2/05-building-a-rag-chatbot.ipynb). It walks through building the full `RAGChatbot` class, indexing a small corpus, querying with source citations, and exercising a "don't-know" fallback case.

--- a/technology_and_tooling/chatbot_development/m3-01-agentic-rag.md
+++ b/technology_and_tooling/chatbot_development/m3-01-agentic-rag.md
@@ -12,6 +12,7 @@ attribution:
   - citation: >
       Oxford AI Competency Centre (2026). Chatbot Development Course.
     url: https://github.com/OxfordCompetencyCenters/aicc_chatbot_modules
+    image: https://github.com/OxfordCompetencyCenters.png
     license: CC-BY-4.0
 ---
 

--- a/technology_and_tooling/chatbot_development/m3-01-agentic-rag.md
+++ b/technology_and_tooling/chatbot_development/m3-01-agentic-rag.md
@@ -1,0 +1,175 @@
+---
+name: Agentic RAG
+dependsOn:
+  - technology_and_tooling.chatbot_development.m2-05-building-a-rag-chatbot
+tags: [chatbots, rag, agents]
+learningOutcomes:
+  - Identify the limitations of single-step retrieval for complex queries.
+  - Implement query expansion to improve retrieval recall.
+  - Use query decomposition to handle multi-part questions.
+  - Build a multi-step retrieval pipeline with deduplication and ranking.
+attribution:
+  - citation: >
+      Oxford AI Competency Centre (2026). Chatbot Development Course.
+    url: https://github.com/OxfordCompetencyCenters/aicc_chatbot_modules
+    license: CC-BY-4.0
+---
+
+The basic RAG system you built in Module 2 follows a straightforward pipeline: take the user's query, embed it, search the vector database, retrieve the top results, and generate a response. This works well for simple, well-phrased questions. But real users ask complex, ambiguous, and multi-part questions that a single retrieval step often can't handle. Agentic RAG addresses this by making the retrieval process iterative and intelligent.
+
+## The Limitations of Single-Step Retrieval
+
+Consider what happens when a user asks "Compare Python and JavaScript for web development." A single-step retrieval embeds this entire question as one vector and searches for similar chunks. The results might be documents that mention both Python and JavaScript together, but they're unlikely to include the best documents about Python web frameworks *and* the best documents about JavaScript web frameworks separately. The query is too broad for a single embedding to capture both facets.
+
+The problem gets worse with ambiguous queries. If a user in a multi-turn conversation asks "How do I use it?", single-step retrieval has no way to resolve what "it" refers to without conversation context. It will embed the literal words and return generic or irrelevant results.
+
+Multi-hop questions pose yet another challenge. "What framework does the creator of Python recommend for web development?" requires two retrieval steps: first, find out who created Python (Guido van Rossum), then search for his framework recommendations. No single embedding can capture both hops.
+
+Finally, there's the vocabulary mismatch problem. If the user asks about "handling errors" but your documents use the term "exception management", the embeddings might not be close enough for a strong match. A single retrieval gives you one shot to find the right documents.
+
+Agentic RAG solves these problems by using the LLM itself to reformulate queries, break complex questions into sub-questions, and perform multiple retrieval steps that are then combined intelligently.
+
+## Query Expansion
+
+Query expansion generates multiple variations of the user's original question, each phrased differently. By searching with several variations, you're more likely to hit documents that use different terminology.
+
+```python
+def expand_query(original_query):
+    """Generate multiple phrasings of the same question."""
+    prompt = f"""Given this user question, generate 3 alternative phrasings
+    that preserve the meaning but use different words.
+
+    Original: {original_query}
+
+    Generate 3 variations:"""
+
+    response = openai.ChatCompletion.create(
+        model="gpt-3.5-turbo",
+        messages=[{"role": "user", "content": prompt}],
+        temperature=0.7
+    )
+
+    variations = response.choices[0].message.content.split('\n')
+    return [original_query] + [v.strip() for v in variations if v.strip()]
+```
+
+For the query "How do I handle errors in Python?", this might produce:
+
+```
+["How do I handle errors in Python?",
+ "What is exception handling in Python?",
+ "How to catch and manage exceptions in Python?",
+ "Python error and exception management techniques"]
+```
+
+Now you search the vector database with all four queries. A document about "exception handling" that might not have matched the original phrasing will likely match one of the expanded versions. The cost is additional LLM and embedding calls, but for high-value queries the quality improvement is significant.
+
+## Query Decomposition
+
+For complex questions that involve multiple distinct sub-topics, decomposition is more appropriate than expansion. Instead of rephrasing the same question, decomposition breaks it into independent sub-questions that can each be answered by retrieving different documents.
+
+```python
+def decompose_query(complex_query):
+    """Break a complex question into simpler sub-questions."""
+    prompt = f"""Break this complex question into simpler sub-questions
+    that can each be answered independently:
+
+    Complex Question: {complex_query}
+
+    Sub-questions:"""
+
+    response = openai.ChatCompletion.create(
+        model="gpt-3.5-turbo",
+        messages=[{"role": "user", "content": prompt}],
+        temperature=0.3
+    )
+
+    subquestions = response.choices[0].message.content.split('\n')
+    return [q.strip() for q in subquestions if q.strip()]
+```
+
+For "Compare Python and JavaScript for building web applications", decomposition might produce:
+
+```
+["What are Python's features for web development?",
+ "What are JavaScript's features for web development?",
+ "What are common Python web frameworks?",
+ "What are common JavaScript web frameworks?"]
+```
+
+Each sub-question targets a different set of documents, and together they cover the breadth of the original question. The LLM can then synthesise the retrieved results into a coherent comparison.
+
+## Building a Multi-Step Retrieval Pipeline
+
+The following implementation brings query expansion, multiple retrievals, deduplication, and frequency-based ranking together into a single class:
+
+```python
+class AgenticRAG:
+    def __init__(self, collection):
+        self.collection = collection
+
+    def agentic_retrieve(self, query, strategy="expand"):
+        """Multi-step retrieval with query expansion or decomposition."""
+        if strategy == "expand":
+            queries = self.expand_query(query)
+        elif strategy == "decompose":
+            queries = self.decompose_query(query)
+        else:
+            queries = [query]
+
+        # Retrieve for each query variant
+        all_results = []
+        for q in queries:
+            results = self.retrieve_documents(q, top_k=3)
+            all_results.extend(results)
+
+        # Deduplicate and rank
+        unique_results = self.deduplicate(all_results)
+        ranked_results = self.rank_by_frequency(unique_results)
+
+        return ranked_results[:5]
+
+    def deduplicate(self, documents):
+        """Remove duplicate documents that appeared across multiple queries."""
+        seen = set()
+        unique = []
+        for doc in documents:
+            doc_id = doc.get('id') or hash(doc['text'])
+            if doc_id not in seen:
+                seen.add(doc_id)
+                unique.append(doc)
+        return unique
+
+    def rank_by_frequency(self, documents):
+        """Rank documents by how often they appeared across query variants."""
+        from collections import Counter
+        doc_counts = Counter([doc['id'] for doc in documents])
+        return sorted(documents, key=lambda doc: doc_counts[doc['id']], reverse=True)
+
+    def chat(self, user_query):
+        """Answer using agentic retrieval."""
+        documents = self.agentic_retrieve(user_query, strategy="expand")
+        context = "\n\n".join([doc['text'] for doc in documents])
+
+        prompt = f"""Context:\n{context}\n\nQuestion: {user_query}\n\nAnswer:"""
+
+        response = openai.ChatCompletion.create(
+            model="gpt-3.5-turbo",
+            messages=[
+                {"role": "system", "content": "Answer based on the provided context."},
+                {"role": "user", "content": prompt}
+            ]
+        )
+
+        return response.choices[0].message.content
+```
+
+The frequency-based ranking is a simple but effective heuristic: documents that appear in the results for multiple query variants are likely more relevant than documents that appear for only one. If a document about Python exception handling is retrieved by "handle errors", "exception handling", and "catch exceptions", it's almost certainly a good match.
+
+In production, you'd choose between expansion and decomposition based on the query. Simple questions benefit from expansion (same question, different words). Complex or multi-part questions benefit from decomposition (different questions entirely). You could even use the LLM to classify the query type before deciding which strategy to use.
+
+The trade-off is cost and latency. Each expanded or decomposed query requires an embedding call and a vector search. A query that expands into four variants takes roughly four times as long as a single retrieval. For latency-sensitive applications, you might reserve agentic retrieval for queries where basic retrieval returns low-confidence results, and use single-step retrieval for straightforward questions.
+
+## Hands-on practical
+
+Work through the accompanying notebook: [`module_3/01-agentic-rag.ipynb`](https://github.com/OxfordCompetencyCenters/aicc_chatbot_modules/blob/main/module_3/01-agentic-rag.ipynb). It walks through query expansion, query decomposition, and a multi-step retrieval pipeline with deduplication plus frequency ranking.

--- a/technology_and_tooling/chatbot_development/m3-02-reranking-and-hybrid-search.md
+++ b/technology_and_tooling/chatbot_development/m3-02-reranking-and-hybrid-search.md
@@ -12,6 +12,7 @@ attribution:
   - citation: >
       Oxford AI Competency Centre (2026). Chatbot Development Course.
     url: https://github.com/OxfordCompetencyCenters/aicc_chatbot_modules
+    image: https://github.com/OxfordCompetencyCenters.png
     license: CC-BY-4.0
 ---
 

--- a/technology_and_tooling/chatbot_development/m3-02-reranking-and-hybrid-search.md
+++ b/technology_and_tooling/chatbot_development/m3-02-reranking-and-hybrid-search.md
@@ -1,0 +1,225 @@
+---
+name: Re-ranking and Hybrid Search
+dependsOn:
+  - technology_and_tooling.chatbot_development.m3-01-agentic-rag
+tags: [chatbots, rag, search]
+learningOutcomes:
+  - Explain why vector search alone can produce imprecise results and how re-ranking helps.
+  - Implement cross-encoder re-ranking using a two-stage retrieval pipeline.
+  - Understand the difference between dense (semantic) and sparse (keyword) retrieval.
+  - Build a hybrid search system that combines BM25 with vector search.
+attribution:
+  - citation: >
+      Oxford AI Competency Centre (2026). Chatbot Development Course.
+    url: https://github.com/OxfordCompetencyCenters/aicc_chatbot_modules
+    license: CC-BY-4.0
+---
+
+Agentic RAG improves retrieval by generating better queries. The two techniques in this section — re-ranking and hybrid search — improve retrieval by making the search and ranking process itself more sophisticated.
+
+## The Precision Problem in Vector Search
+
+Vector search is fast and captures semantic meaning, but its ranking isn't always precise. There are several reasons for this.
+
+First, vector databases use **approximate** nearest neighbour algorithms. They sacrifice a small amount of accuracy for dramatic speed improvements. The top result from an approximate search isn't always the true nearest neighbour — it's usually close, but "close" isn't always good enough.
+
+Second, each document chunk is compressed into a single embedding vector. All the nuance of a 500-word passage is reduced to 1,536 numbers. This compression inevitably loses fine-grained relevance signals. Two passages might have similar embeddings because they discuss the same general topic, even though one directly answers the user's question and the other is tangentially related.
+
+Third, embedding similarity doesn't always correspond to relevance. "Python tutorial" and "Python snake" might have somewhat similar embeddings because they share the word "Python", even though they're about completely different topics.
+
+The solution is a **two-stage retrieval** pipeline. In the first stage, vector search casts a wide net and retrieves a large set of candidates — say, the top 20. This stage prioritises recall: find everything that might be relevant. In the second stage, a more sophisticated model examines each candidate individually and re-scores it for relevance to the specific query. This stage prioritises precision: among the candidates, which are truly the best matches? Only the top 3–5 re-ranked results are passed to the LLM.
+
+## Cross-Encoder Re-ranking
+
+A cross-encoder is a model specifically trained to score the relevance of a (query, document) pair. Unlike the bi-encoder approach used for embeddings — where the query and document are embedded separately and then compared — a cross-encoder processes the query and document together, allowing it to capture fine-grained interactions between them. This makes it significantly more accurate, but also significantly slower. That's why it's used only on a small set of pre-filtered candidates, not the entire corpus.
+
+Here's an implementation using the `sentence-transformers` library:
+
+```python
+from sentence_transformers import CrossEncoder
+
+class RerankedRAG:
+    def __init__(self, collection):
+        self.collection = collection
+        self.reranker = CrossEncoder('cross-encoder/ms-marco-MiniLM-L-6-v2')
+
+    def retrieve_and_rerank(self, query, initial_k=20, final_k=5):
+        """Two-stage retrieval: vector search then cross-encoder re-ranking."""
+
+        # Stage 1: Cast a wide net with vector search
+        candidates = self.retrieve_documents(query, top_k=initial_k)
+
+        # Stage 2: Score each candidate against the query
+        pairs = [[query, doc['text']] for doc in candidates]
+        scores = self.reranker.predict(pairs)
+
+        # Attach scores and sort
+        for doc, score in zip(candidates, scores):
+            doc['rerank_score'] = float(score)
+
+        reranked = sorted(candidates, key=lambda x: x['rerank_score'], reverse=True)
+
+        return reranked[:final_k]
+
+    def chat(self, user_query):
+        """RAG with re-ranking."""
+        documents = self.retrieve_and_rerank(user_query)
+
+        context = "\n\n".join([doc['text'] for doc in documents])
+
+        prompt = f"""Context:\n{context}\n\nQuestion: {user_query}\n\nAnswer:"""
+
+        response = openai.ChatCompletion.create(
+            model="gpt-3.5-turbo",
+            messages=[
+                {"role": "system", "content": "Answer based on the provided context."},
+                {"role": "user", "content": prompt}
+            ]
+        )
+
+        return response.choices[0].message.content
+```
+
+To use this, install the required library:
+
+```bash
+pip install sentence-transformers
+```
+
+Several pre-trained cross-encoder models are available, trained on the MS MARCO search relevance dataset. They differ in speed and accuracy:
+
+- `cross-encoder/ms-marco-MiniLM-L-6-v2` — fast, good quality (recommended starting point)
+- `cross-encoder/ms-marco-TinyBERT-L-2-v2` — faster, slightly lower quality
+- `cross-encoder/ms-marco-electra-base` — slower, highest quality
+
+In practice, re-ranking typically improves Precision@5 by 15–40%. The added latency is modest because you're only scoring 20 candidates, not millions. For most production RAG systems, the quality improvement is well worth the cost.
+
+## Dense vs Sparse Retrieval
+
+So far, all our retrieval has been **dense** — using vector embeddings to capture semantic similarity. But there's another approach that's been used in information retrieval for decades: **sparse** retrieval, commonly implemented as BM25 (a refinement of TF-IDF).
+
+Dense retrieval represents text as dense vectors where every dimension has a value. It excels at semantic understanding: "automobile" and "car" have similar embeddings even though they share no characters. But it can struggle with exact matches. If a user searches for product code "XR-7821", dense search might return documents about products in general rather than the specific product, because the embedding doesn't strongly encode the exact string.
+
+Sparse retrieval represents text as sparse vectors where most dimensions are zero. Each dimension corresponds to a word in the vocabulary, and the value reflects how important that word is in the document (based on frequency and rarity). Sparse retrieval excels at exact keyword matching: "XR-7821" will match documents containing exactly that string. But it fails on synonyms: "automobile" and "car" are completely different words and won't match.
+
+The two approaches are complementary. Dense search understands meaning; sparse search finds exact terms. For most production systems, combining them — hybrid search — outperforms either approach alone.
+
+## Implementing Hybrid Search
+
+Hybrid search runs both dense (vector) and sparse (BM25) retrieval on every query, then combines the results using a weighted score. The `alpha` parameter controls the balance between the two approaches.
+
+```python
+from rank_bm25 import BM25Okapi
+import numpy as np
+
+class HybridRAG:
+    def __init__(self, collection):
+        self.collection = collection
+        self.documents = []
+        self.bm25 = None
+
+    def index_documents(self, documents):
+        """Index documents for both vector and BM25 search."""
+        self.documents = documents
+
+        # Vector indexing happens via ChromaDB (as before)
+        # ...
+
+        # BM25 indexing
+        tokenized_docs = [doc.lower().split() for doc in documents]
+        self.bm25 = BM25Okapi(tokenized_docs)
+
+    def hybrid_search(self, query, top_k=5, alpha=0.5):
+        """
+        Combine vector and BM25 search.
+
+        alpha=1.0 means pure dense search.
+        alpha=0.0 means pure sparse search.
+        alpha=0.5 means equal weight.
+        """
+        # Dense retrieval
+        vector_results = self.collection.query(
+            query_embeddings=[self.embed_query(query)],
+            n_results=top_k * 2
+        )
+
+        # Sparse retrieval
+        tokenized_query = query.lower().split()
+        bm25_scores = self.bm25.get_scores(tokenized_query)
+
+        # Normalise both score sets to [0, 1]
+        vector_scores_norm = self._normalize(vector_results['distances'][0])
+        bm25_scores_norm = self._normalize(bm25_scores)
+
+        # Combine with weighted sum
+        combined_scores = {}
+        for idx, doc in enumerate(self.documents):
+            combined = (
+                alpha * vector_scores_norm[idx] +
+                (1 - alpha) * bm25_scores_norm[idx]
+            )
+            combined_scores[idx] = combined
+
+        # Return top K
+        top_indices = sorted(
+            combined_scores.keys(),
+            key=lambda i: combined_scores[i],
+            reverse=True
+        )[:top_k]
+
+        return [self.documents[i] for i in top_indices]
+
+    def _normalize(self, scores):
+        """Normalise scores to [0, 1] range."""
+        scores = np.array(scores)
+        if scores.max() == scores.min():
+            return scores
+        return (scores - scores.min()) / (scores.max() - scores.min())
+```
+
+Install BM25 with:
+
+```bash
+pip install rank-bm25
+```
+
+The `alpha` parameter is the key tuning knob. For queries that are likely semantic in nature ("How do I handle errors in my code?"), set alpha higher (0.7–0.9) to weight dense search more heavily. For queries that contain specific identifiers or technical terms ("bug #12345", "API endpoint /v2/users"), set alpha lower (0.2–0.3) to weight keyword matching more heavily. For general queries, 0.5 is a reasonable default.
+
+In a sophisticated system, you could even choose alpha dynamically based on the query. If the query contains tokens that look like identifiers (numbers, codes, URLs), reduce alpha. If it's a natural language question, increase alpha. This kind of adaptive hybrid search is used in production by companies like Notion and Stripe.
+
+::::challenge{id=m3-02-compare title="Implement and Compare Retrieval Strategies"}
+
+Starting from your Module 2 RAG system, add re-ranking and hybrid search, then compare all approaches.
+
+**Step 1: Add re-ranking.** Retrieve 20 candidates with vector search, re-rank them with a cross-encoder, and return the top 5. Compare Precision@5 against your baseline.
+
+```python
+from sentence_transformers import CrossEncoder
+
+# TODO: Implement retrieve_and_rerank
+# Retrieve top 20 candidates, re-rank with cross-encoder, return top 5
+
+# Compare against baseline
+print(f"Baseline P@5: {baseline_precision:.2f}")
+print(f"Reranked P@5: {reranked_precision:.2f}")
+```
+
+**Step 2: Add hybrid search.** Index your documents for BM25 alongside the existing vector index. Implement the hybrid search function and experiment with different alpha values.
+
+```python
+from rank_bm25 import BM25Okapi
+
+# TODO: Implement hybrid search with configurable alpha
+
+# Find the best alpha
+for alpha in [0.0, 0.3, 0.5, 0.7, 1.0]:
+    precision = evaluate_with_alpha(alpha)
+    print(f"Alpha {alpha}: P@5 = {precision:.2f}")
+```
+
+**Step 3: Combine everything.** Use hybrid search to retrieve candidates, then re-rank. Does combining both techniques outperform either alone?
+::::
+
+## Hands-on practical
+
+Work through the accompanying notebook: [`module_3/02-reranking-and-hybrid-search.ipynb`](https://github.com/OxfordCompetencyCenters/aicc_chatbot_modules/blob/main/module_3/02-reranking-and-hybrid-search.ipynb). It walks through vector search as a baseline, an LLM-based re-ranker on top of it, BM25 keyword search with `rank-bm25`, and a tunable hybrid combination.

--- a/technology_and_tooling/chatbot_development/m3-03-knowledge-graphs.md
+++ b/technology_and_tooling/chatbot_development/m3-03-knowledge-graphs.md
@@ -12,6 +12,7 @@ attribution:
   - citation: >
       Oxford AI Competency Centre (2026). Chatbot Development Course.
     url: https://github.com/OxfordCompetencyCenters/aicc_chatbot_modules
+    image: https://github.com/OxfordCompetencyCenters.png
     license: CC-BY-4.0
 ---
 

--- a/technology_and_tooling/chatbot_development/m3-03-knowledge-graphs.md
+++ b/technology_and_tooling/chatbot_development/m3-03-knowledge-graphs.md
@@ -1,7 +1,7 @@
 ---
 name: Knowledge Graphs
 dependsOn:
-  - technology_and_tooling.chatbot_development.m3-02-reranking-and-hybrid-search
+  - technology_and_tooling.chatbot_development.m3-01-agentic-rag
 tags: [chatbots, rag, knowledge-graphs]
 learningOutcomes:
   - Explain what knowledge graphs are and when they complement vector search.

--- a/technology_and_tooling/chatbot_development/m3-03-knowledge-graphs.md
+++ b/technology_and_tooling/chatbot_development/m3-03-knowledge-graphs.md
@@ -1,0 +1,257 @@
+---
+name: Knowledge Graphs
+dependsOn:
+  - technology_and_tooling.chatbot_development.m3-02-reranking-and-hybrid-search
+tags: [chatbots, rag, knowledge-graphs]
+learningOutcomes:
+  - Explain what knowledge graphs are and when they complement vector search.
+  - Build a simple knowledge graph using NetworkX.
+  - Extract entities and relationships from text using LLMs.
+  - Combine vector search with knowledge graph reasoning in a hybrid system.
+attribution:
+  - citation: >
+      Oxford AI Competency Centre (2026). Chatbot Development Course.
+    url: https://github.com/OxfordCompetencyCenters/aicc_chatbot_modules
+    license: CC-BY-4.0
+---
+
+Vector search and BM25 are both good at finding documents that are *similar* to a query. But some questions aren't about similarity — they're about *relationships*. "Who created Python?" "What frameworks are built with Python?" "What programming languages were created by people who worked at Google?" These questions require traversing explicit connections between entities, not searching for similar text. That's where knowledge graphs come in.
+
+## What Are Knowledge Graphs?
+
+A knowledge graph represents information as a network of **entities** (things) connected by **relationships** (how those things relate to each other). Each fact in the graph is a triple: (entity, relationship, entity). For example:
+
+```
+(Python) --created_by--> (Guido van Rossum)
+(Python) --released_in--> (1991)
+(Python) --used_for--> (Web Development)
+(Python) --used_for--> (Data Science)
+(Guido van Rossum) --nationality--> (Dutch)
+(Guido van Rossum) --worked_at--> (Google)
+(Django) --built_with--> (Python)
+(Django) --used_for--> (Web Development)
+```
+
+This structure makes it easy to answer relationship questions by traversing the graph. "Who created Python?" — follow the `created_by` edge from Python. "What frameworks use Python?" — find all nodes connected to Python by the `built_with` relationship. "What languages were created by people who worked at Google?" — find people with `worked_at → Google`, then follow their `created` edges. That last query requires two hops through the graph — something that vector search cannot do at all.
+
+Knowledge graphs and vector databases serve different purposes:
+
+| Aspect | Vector Database | Knowledge Graph |
+|--------|----------------|-----------------|
+| Data type | Unstructured text | Structured relationships |
+| Search method | Semantic similarity | Graph traversal |
+| Reasoning | Statistical | Explicit, rule-based |
+| Best for | Finding similar content | Understanding relationships |
+
+In practice, many production systems use both. Vector search handles "how-to" and "explain" questions where the answer lives in document text. Knowledge graphs handle "who", "when", "where", and "what relates to what" questions where the answer is a specific fact or a chain of relationships.
+
+## Building a Knowledge Graph with NetworkX
+
+For prototyping, Python's `networkx` library provides everything you need. In production, you'd use a dedicated graph database like Neo4j, Amazon Neptune, or TigerGraph, but the concepts are identical.
+
+```python
+import networkx as nx
+
+class SimpleKnowledgeGraph:
+    def __init__(self):
+        self.graph = nx.DiGraph()  # Directed graph
+
+    def add_entity(self, entity, entity_type=None, properties=None):
+        """Add an entity (node) to the graph."""
+        self.graph.add_node(
+            entity,
+            type=entity_type,
+            properties=properties or {}
+        )
+
+    def add_relationship(self, entity1, relationship, entity2):
+        """Add a relationship (directed edge) between two entities."""
+        self.graph.add_edge(entity1, entity2, relation=relationship)
+
+    def query(self, start_entity, relationship):
+        """Find all entities connected to start_entity by a given relationship."""
+        results = []
+        for neighbor in self.graph.successors(start_entity):
+            edge_data = self.graph.get_edge_data(start_entity, neighbor)
+            if edge_data and edge_data.get('relation') == relationship:
+                results.append(neighbor)
+        return results
+
+    def get_neighbors(self, entity, max_depth=2):
+        """Find all entities within max_depth hops."""
+        visited = set()
+        to_visit = [(entity, 0)]
+        results = []
+
+        while to_visit:
+            current, depth = to_visit.pop(0)
+            if current in visited or depth > max_depth:
+                continue
+            visited.add(current)
+
+            for neighbor in self.graph.successors(current):
+                edge_data = self.graph.get_edge_data(current, neighbor)
+                results.append({
+                    "from": current,
+                    "relation": edge_data.get('relation'),
+                    "to": neighbor
+                })
+                to_visit.append((neighbor, depth + 1))
+
+        return results
+```
+
+Here's how to populate and query it:
+
+```python
+kg = SimpleKnowledgeGraph()
+
+# Add entities
+kg.add_entity("Python", entity_type="Programming Language")
+kg.add_entity("Guido van Rossum", entity_type="Person")
+kg.add_entity("Django", entity_type="Framework")
+kg.add_entity("Web Development", entity_type="Domain")
+
+# Add relationships
+kg.add_relationship("Python", "created_by", "Guido van Rossum")
+kg.add_relationship("Django", "built_with", "Python")
+kg.add_relationship("Django", "used_for", "Web Development")
+kg.add_relationship("Python", "used_for", "Web Development")
+
+# Simple queries
+creator = kg.query("Python", "created_by")
+print(f"Python was created by: {creator}")  # ["Guido van Rossum"]
+
+# Multi-hop: everything connected to Python within 2 hops
+related = kg.get_neighbors("Python", max_depth=2)
+for r in related:
+    print(f"  {r['from']} --{r['relation']}--> {r['to']}")
+```
+
+## Extracting Entities from Documents
+
+Manually building a knowledge graph is fine for small, well-defined domains. But for large document corpora, you need automated extraction. LLMs are surprisingly good at identifying entities and relationships in text.
+
+```python
+def extract_entities_and_relationships(text):
+    """Use an LLM to extract structured knowledge from text."""
+    prompt = f"""Extract entities and relationships from the text below.
+
+    Text: {text}
+
+    Output format:
+    Entities:
+    - EntityName (EntityType)
+
+    Relationships:
+    - (Entity1, relationship, Entity2)
+    """
+
+    response = openai.ChatCompletion.create(
+        model="gpt-4",
+        messages=[{"role": "user", "content": prompt}],
+        temperature=0.0
+    )
+
+    return response.choices[0].message.content
+```
+
+For example, given the text "Python is a programming language created by Guido van Rossum in 1991. Django is a popular web framework built with Python", the LLM would extract:
+
+```
+Entities:
+- Python (Programming Language)
+- Guido van Rossum (Person)
+- Django (Framework)
+
+Relationships:
+- (Python, created_by, Guido van Rossum)
+- (Python, released_in, 1991)
+- (Django, built_with, Python)
+```
+
+For faster extraction that doesn't require LLM calls, you can use NER (Named Entity Recognition) libraries like spaCy:
+
+```python
+import spacy
+
+nlp = spacy.load("en_core_web_sm")
+
+def extract_entities_spacy(text):
+    """Extract named entities using spaCy."""
+    doc = nlp(text)
+    return [{"text": ent.text, "type": ent.label_} for ent in doc.ents]
+```
+
+spaCy is faster and cheaper (no API calls), but it only extracts entities — not relationships. LLMs can extract both, but at the cost of API calls and latency. In practice, you might use spaCy for entity extraction at scale and LLMs for relationship extraction on a smaller, curated subset of documents.
+
+## Combining Vector Search with Knowledge Graphs
+
+The most powerful approach is to use both vector search and knowledge graph reasoning in a single system. The key is deciding which questions need which approach.
+
+```python
+class HybridRAGKG:
+    def __init__(self, vector_collection, knowledge_graph):
+        self.vector_collection = vector_collection
+        self.kg = knowledge_graph
+
+    def query(self, user_question):
+        """Route the query to vector search, knowledge graph, or both."""
+
+        # Determine if the query involves entity relationships
+        needs_kg = self.requires_graph_reasoning(user_question)
+
+        # Knowledge graph context
+        kg_context = ""
+        if needs_kg:
+            entities = self.extract_entities_from_question(user_question)
+            kg_results = []
+            for entity in entities:
+                related = self.kg.get_neighbors(entity, max_depth=2)
+                kg_results.extend(related)
+            kg_context = self.format_kg_results(kg_results)
+
+        # Vector search context
+        vector_docs = self.vector_search(user_question, top_k=3)
+        vector_context = "\n\n".join(vector_docs)
+
+        # Combine and generate
+        combined_context = f"""Knowledge Graph Information:
+{kg_context}
+
+Document Information:
+{vector_context}"""
+
+        prompt = f"""Context:
+{combined_context}
+
+Question: {user_question}
+
+Answer the question using both the structured knowledge graph information
+and the document content. Cite your sources."""
+
+        response = openai.ChatCompletion.create(
+            model="gpt-3.5-turbo",
+            messages=[{"role": "user", "content": prompt}]
+        )
+
+        return response.choices[0].message.content
+
+    def requires_graph_reasoning(self, question):
+        """Simple heuristic: does the question ask about relationships?"""
+        relationship_keywords = [
+            "who created", "when was", "where is",
+            "relationship between", "connected to",
+            "works at", "founder of", "related to"
+        ]
+        question_lower = question.lower()
+        return any(kw in question_lower for kw in relationship_keywords)
+```
+
+With this hybrid approach, a question like "How do I use Python list comprehensions?" routes primarily through vector search, retrieving relevant tutorial text. A question like "Who created Python and what companies did they work for?" routes through the knowledge graph, following the relationship chain from Python to its creator to their employment history. And a question like "What web frameworks use the language created by Guido?" uses both: the knowledge graph to resolve "language created by Guido" to "Python", and then vector search to find detailed information about Python web frameworks.
+
+Knowledge graphs are not necessary for every RAG system. They add complexity and require either manual curation or an extraction pipeline. But for domains with rich entity relationships — organisational structures, product ecosystems, regulatory frameworks, scientific taxonomies — they can answer questions that pure vector search simply cannot.
+
+## Hands-on practical
+
+Work through the accompanying notebook: [`module_3/03-knowledge-graphs.ipynb`](https://github.com/OxfordCompetencyCenters/aicc_chatbot_modules/blob/main/module_3/03-knowledge-graphs.ipynb). It walks through building a small directed graph with NetworkX, extracting triples via the LLM, multi-hop queries, and a simple heuristic for routing questions to graph vs vector search.

--- a/technology_and_tooling/chatbot_development/m3-04-semantic-caching.md
+++ b/technology_and_tooling/chatbot_development/m3-04-semantic-caching.md
@@ -1,7 +1,7 @@
 ---
 name: Semantic Caching
 dependsOn:
-  - technology_and_tooling.chatbot_development.m3-03-knowledge-graphs
+  - technology_and_tooling.chatbot_development.m3-01-agentic-rag
 tags: [chatbots, rag, caching, optimization]
 learningOutcomes:
   - Explain why traditional exact-match caching is insufficient for chatbot queries.

--- a/technology_and_tooling/chatbot_development/m3-04-semantic-caching.md
+++ b/technology_and_tooling/chatbot_development/m3-04-semantic-caching.md
@@ -1,0 +1,179 @@
+---
+name: Semantic Caching
+dependsOn:
+  - technology_and_tooling.chatbot_development.m3-03-knowledge-graphs
+tags: [chatbots, rag, caching, optimization]
+learningOutcomes:
+  - Explain why traditional exact-match caching is insufficient for chatbot queries.
+  - Implement a semantic cache that matches similar (not identical) queries.
+  - Configure similarity thresholds and TTL for cache accuracy and freshness.
+  - Integrate semantic caching into a RAG pipeline to reduce cost and latency.
+attribution:
+  - citation: >
+      Oxford AI Competency Centre (2026). Chatbot Development Course.
+    url: https://github.com/OxfordCompetencyCenters/aicc_chatbot_modules
+    license: CC-BY-4.0
+---
+
+Every RAG query involves at least three expensive operations: embedding the query, searching the vector database, and calling the LLM to generate a response. In a production system handling thousands of queries per day, these costs add up. Semantic caching can reduce them dramatically by storing responses and returning them for similar future queries — without repeating the full retrieval and generation pipeline.
+
+## The Problem with Exact-Match Caching
+
+Traditional caching stores a response for a specific input and returns it when the exact same input appears again:
+
+```python
+cache = {}
+if query in cache:
+    return cache[query]
+else:
+    result = expensive_rag_call(query)
+    cache[query] = result
+    return result
+```
+
+This works for APIs where the input is deterministic, but chatbot queries are natural language. Users don't type the same question the same way twice. "How do I deploy my app?", "How to deploy application?", "Deployment instructions?", and "Steps to deploy" all ask for the same information, but none of them are exact string matches. An exact-match cache would miss all of these and make four separate RAG calls.
+
+Semantic caching solves this by comparing the *meaning* of queries rather than their exact text. If a new query is semantically similar enough to a cached query, the cached response is returned. This can reduce LLM API calls by 40–60% in systems where users frequently ask about the same topics.
+
+## Implementing a Semantic Cache
+
+The implementation uses the same embeddings and vector search that power RAG itself. Instead of storing document chunks, the cache stores (query, response) pairs. When a new query arrives, it's embedded and compared against the cached query embeddings. If a close enough match is found (above a similarity threshold) and the cached entry hasn't expired (within the TTL), the cached response is returned directly.
+
+```python
+import chromadb
+import openai
+from datetime import datetime, timedelta
+
+class SemanticCache:
+    def __init__(self, similarity_threshold=0.95, ttl_hours=24):
+        """
+        similarity_threshold: Minimum cosine similarity for a cache hit.
+            Higher values (0.97-0.99) mean fewer false positives but lower hit rate.
+            Lower values (0.90-0.93) mean more hits but risk returning slightly
+            off-target answers.
+        ttl_hours: How long cache entries remain valid.
+        """
+        self.client = chromadb.PersistentClient(path="./cache_db")
+        self.collection = self.client.get_or_create_collection("query_cache")
+        self.similarity_threshold = similarity_threshold
+        self.ttl = timedelta(hours=ttl_hours)
+
+    def _embed_query(self, query):
+        """Generate an embedding for a query."""
+        response = openai.Embedding.create(
+            model="text-embedding-3-small",
+            input=query
+        )
+        return response['data'][0]['embedding']
+
+    def find_similar(self, query):
+        """Check if a similar query is already cached."""
+        if self.collection.count() == 0:
+            return None
+
+        query_embedding = self._embed_query(query)
+
+        results = self.collection.query(
+            query_embeddings=[query_embedding],
+            n_results=1
+        )
+
+        if not results['ids'][0]:
+            return None
+
+        # Check similarity threshold
+        distance = results['distances'][0][0]
+        similarity = 1 - distance
+
+        if similarity >= self.similarity_threshold:
+            # Check TTL
+            metadata = results['metadatas'][0][0]
+            cached_time = datetime.fromisoformat(metadata['timestamp'])
+
+            if datetime.now() - cached_time < self.ttl:
+                return results['ids'][0][0]
+
+        return None
+
+    def get(self, query_id):
+        """Retrieve a cached response by query ID."""
+        result = self.collection.get(ids=[query_id])
+        if result['metadatas']:
+            return result['metadatas'][0]['response']
+        return None
+
+    def store(self, query, response):
+        """Store a query-response pair in the cache."""
+        query_embedding = self._embed_query(query)
+
+        self.collection.add(
+            ids=[f"query_{hash(query)}"],
+            embeddings=[query_embedding],
+            documents=[query],
+            metadatas=[{
+                "response": response,
+                "timestamp": datetime.now().isoformat()
+            }]
+        )
+```
+
+## Integrating the Cache into Your RAG Pipeline
+
+Wrapping your existing RAG system with semantic caching requires only a thin layer:
+
+```python
+class CachedRAG:
+    def __init__(self, rag_system, similarity_threshold=0.95, ttl_hours=24):
+        self.rag = rag_system
+        self.cache = SemanticCache(
+            similarity_threshold=similarity_threshold,
+            ttl_hours=ttl_hours
+        )
+
+    def chat(self, user_query):
+        """Chat with semantic caching."""
+        # Check cache first
+        cached_query_id = self.cache.find_similar(user_query)
+
+        if cached_query_id:
+            return self.cache.get(cached_query_id)
+
+        # Cache miss — generate a fresh response
+        response = self.rag.chat(user_query)
+
+        # Store in cache for future similar queries
+        self.cache.store(user_query, response)
+
+        return response
+```
+
+Usage is transparent to the rest of your code:
+
+```python
+cached_rag = CachedRAG(rag_system)
+
+# First call — cache miss, full RAG pipeline runs
+answer1 = cached_rag.chat("How do I deploy my app?")
+
+# Similar query — cache hit, returns instantly
+answer2 = cached_rag.chat("How to deploy application?")
+
+# Different topic — cache miss, full RAG pipeline runs
+answer3 = cached_rag.chat("What is Python?")
+```
+
+## Tuning the Cache
+
+The two main parameters to tune are the **similarity threshold** and the **TTL**.
+
+The similarity threshold controls how similar a new query must be to a cached query for a cache hit. Setting it too high (0.99) means the cache only matches near-identical queries, which gives you very few hits. Setting it too low (0.85) means the cache matches queries that are somewhat related but not really the same, which can return misleading answers. For most applications, 0.93–0.97 is the sweet spot. Start at 0.95 and adjust based on whether you're seeing false positives (wrong answers returned from cache) or a low hit rate.
+
+The TTL controls how long cached entries remain valid. For documentation that changes infrequently, a longer TTL (24–48 hours) maximises cache utilisation. For rapidly changing data — news, stock prices, real-time dashboards — you need a short TTL (1–4 hours) or even no caching at all for certain query types.
+
+In a production system, you'd also monitor your cache hit rate and the accuracy of cache hits. If users report incorrect answers that turn out to be stale cache entries, your TTL is too long. If your cache hit rate is below 20–30%, your threshold might be too strict or your user base might not have enough query overlap to benefit from caching.
+
+The potential savings are substantial. Companies that have implemented semantic caching report 40–60% reduction in LLM API calls, 50–70% reduction in average response latency (cache hits return near-instantly), and proportional cost savings on embedding and LLM generation. These savings scale with traffic: the more users you have, the more likely any given query has a similar cached predecessor.
+
+## Hands-on practical
+
+Work through the accompanying notebook: [`module_3/04-semantic-caching.ipynb`](https://github.com/OxfordCompetencyCenters/aicc_chatbot_modules/blob/main/module_3/04-semantic-caching.ipynb). It walks through the failure of exact-match caching, a semantic cache built from scratch, threshold tuning, and a `CachedRAG` wrapper around the full pipeline.

--- a/technology_and_tooling/chatbot_development/m3-04-semantic-caching.md
+++ b/technology_and_tooling/chatbot_development/m3-04-semantic-caching.md
@@ -12,6 +12,7 @@ attribution:
   - citation: >
       Oxford AI Competency Centre (2026). Chatbot Development Course.
     url: https://github.com/OxfordCompetencyCenters/aicc_chatbot_modules
+    image: https://github.com/OxfordCompetencyCenters.png
     license: CC-BY-4.0
 ---
 

--- a/technology_and_tooling/chatbot_development/m3-05-evaluating-and-optimising-retrieval.md
+++ b/technology_and_tooling/chatbot_development/m3-05-evaluating-and-optimising-retrieval.md
@@ -1,7 +1,7 @@
 ---
 name: Evaluating and Optimising Retrieval
 dependsOn:
-  - technology_and_tooling.chatbot_development.m3-04-semantic-caching
+  - technology_and_tooling.chatbot_development.m3-01-agentic-rag
 tags: [chatbots, rag, evaluation]
 learningOutcomes:
   - Calculate standard retrieval metrics (Precision@K, Recall@K, MRR).

--- a/technology_and_tooling/chatbot_development/m3-05-evaluating-and-optimising-retrieval.md
+++ b/technology_and_tooling/chatbot_development/m3-05-evaluating-and-optimising-retrieval.md
@@ -12,6 +12,7 @@ attribution:
   - citation: >
       Oxford AI Competency Centre (2026). Chatbot Development Course.
     url: https://github.com/OxfordCompetencyCenters/aicc_chatbot_modules
+    image: https://github.com/OxfordCompetencyCenters.png
     license: CC-BY-4.0
 ---
 

--- a/technology_and_tooling/chatbot_development/m3-05-evaluating-and-optimising-retrieval.md
+++ b/technology_and_tooling/chatbot_development/m3-05-evaluating-and-optimising-retrieval.md
@@ -1,0 +1,246 @@
+---
+name: Evaluating and Optimising Retrieval
+dependsOn:
+  - technology_and_tooling.chatbot_development.m3-04-semantic-caching
+tags: [chatbots, rag, evaluation]
+learningOutcomes:
+  - Calculate standard retrieval metrics (Precision@K, Recall@K, MRR).
+  - Build an evaluation suite to measure retrieval quality objectively.
+  - Compare retrieval strategies using A/B testing with statistical significance.
+  - Make data-driven decisions about which optimisations to deploy.
+attribution:
+  - citation: >
+      Oxford AI Competency Centre (2026). Chatbot Development Course.
+    url: https://github.com/OxfordCompetencyCenters/aicc_chatbot_modules
+    license: CC-BY-4.0
+---
+
+You've now learned several techniques for improving RAG: query expansion, re-ranking, hybrid search, and semantic caching. But how do you know whether these techniques actually help for *your* data and *your* queries? The only way to know is to measure. This section introduces the standard metrics for evaluating retrieval quality and shows you how to build an evaluation framework that lets you compare strategies objectively.
+
+## Retrieval Quality Metrics
+
+Information retrieval has a well-established set of metrics. The ones most relevant to RAG are Precision@K, Recall@K, and Mean Reciprocal Rank (MRR).
+
+**Precision@K** answers the question: of the K documents you retrieved, how many were actually relevant?
+
+```
+Precision@K = (Relevant documents in top K) / K
+```
+
+If you retrieve 5 documents and 3 of them are relevant, your Precision@5 is 3/5 = 0.60. This is the most intuitive metric for RAG because it directly measures the quality of the context you're feeding to the LLM. If your Precision@5 is low, the LLM is receiving a lot of irrelevant context alongside the relevant information, which can confuse it and reduce answer quality.
+
+**Recall@K** answers the question: of all the relevant documents in your corpus, how many did you retrieve in the top K?
+
+```
+Recall@K = (Relevant docs in top K) / (Total relevant docs in corpus)
+```
+
+If there are 10 relevant documents and you retrieved 3 of them, your Recall@5 is 3/10 = 0.30. Recall matters less than precision for most RAG applications, because you typically only need a few good documents to answer a question — you don't need to find every relevant document in the corpus.
+
+**Mean Reciprocal Rank (MRR)** answers the question: how quickly does the first relevant result appear?
+
+```
+MRR = Average of (1 / rank of first relevant result)
+```
+
+If the first relevant result appears at position 1, the reciprocal rank is 1.0. If it appears at position 3, it's 0.33. MRR is averaged across all queries in your test set. A high MRR means your system consistently surfaces a relevant document near the top of the results, which is important because the LLM pays most attention to the context provided first.
+
+## Building an Evaluation Suite
+
+To compute these metrics, you need a test dataset: a set of queries paired with the IDs of documents that should be retrieved for each query. Building this dataset is the hardest part of evaluation, but it's essential.
+
+```python
+class RetrievalEvaluator:
+    def __init__(self, rag_system):
+        self.rag = rag_system
+
+    def precision_at_k(self, query, relevant_doc_ids, k=5):
+        """What fraction of retrieved docs are relevant?"""
+        retrieved = self.rag.retrieve(query, top_k=k)
+        retrieved_ids = [doc['id'] for doc in retrieved]
+        relevant_retrieved = len(set(retrieved_ids) & set(relevant_doc_ids))
+        return relevant_retrieved / k
+
+    def recall_at_k(self, query, relevant_doc_ids, k=5):
+        """What fraction of all relevant docs did we retrieve?"""
+        retrieved = self.rag.retrieve(query, top_k=k)
+        retrieved_ids = [doc['id'] for doc in retrieved]
+        relevant_retrieved = len(set(retrieved_ids) & set(relevant_doc_ids))
+        return relevant_retrieved / len(relevant_doc_ids)
+
+    def mrr(self, query, relevant_doc_ids):
+        """How quickly does the first relevant result appear?"""
+        retrieved = self.rag.retrieve(query, top_k=10)
+        retrieved_ids = [doc['id'] for doc in retrieved]
+
+        for rank, doc_id in enumerate(retrieved_ids, start=1):
+            if doc_id in relevant_doc_ids:
+                return 1.0 / rank
+        return 0.0
+
+    def evaluate_dataset(self, test_queries):
+        """Evaluate across a full test dataset."""
+        precisions, recalls, mrrs = [], [], []
+
+        for item in test_queries:
+            p = self.precision_at_k(item['query'], item['relevant_doc_ids'], k=5)
+            r = self.recall_at_k(item['query'], item['relevant_doc_ids'], k=5)
+            m = self.mrr(item['query'], item['relevant_doc_ids'])
+
+            precisions.append(p)
+            recalls.append(r)
+            mrrs.append(m)
+
+        return {
+            "precision@5": sum(precisions) / len(precisions),
+            "recall@5": sum(recalls) / len(recalls),
+            "mrr": sum(mrrs) / len(mrrs)
+        }
+```
+
+You can create test datasets in two ways. **Manual curation** is the gold standard: read your documents, write natural questions about them, and record which documents each question should retrieve. This is time-consuming but produces high-quality evaluations. Start with 20–30 queries — that's enough to get meaningful signal.
+
+**Synthetic generation** is faster: use an LLM to generate questions for each document, then use the source document as the expected retrieval target.
+
+```python
+def generate_test_queries(document, doc_id):
+    """Use an LLM to generate questions that this document should answer."""
+    prompt = f"""Given this document, generate 3 questions that this document
+    should be able to answer.
+
+    Document: {document}
+
+    Questions:"""
+
+    response = openai.ChatCompletion.create(
+        model="gpt-3.5-turbo",
+        messages=[{"role": "user", "content": prompt}]
+    )
+
+    questions = response.choices[0].message.content.split('\n')
+    return [{"query": q.strip(), "relevant_doc_ids": [doc_id]}
+            for q in questions if q.strip()]
+```
+
+Synthetic test sets are useful for quick iteration, but they can be biased toward the vocabulary of the documents (since the LLM generates questions from the document text). Always supplement with some manually written queries that use different phrasing.
+
+## Comparing Strategies with A/B Testing
+
+Once you have an evaluation suite, you can objectively compare retrieval strategies:
+
+```python
+class RetrievalComparison:
+    def __init__(self):
+        self.strategies = {}
+
+    def add_strategy(self, name, strategy_func):
+        """Register a retrieval strategy for comparison."""
+        self.strategies[name] = strategy_func
+
+    def compare(self, test_queries):
+        """Run all strategies on the test dataset and compare."""
+        results = {name: [] for name in self.strategies}
+
+        for query_item in test_queries:
+            query = query_item['query']
+            relevant_ids = query_item['relevant_doc_ids']
+
+            for name, strategy in self.strategies.items():
+                retrieved = strategy(query, top_k=5)
+                retrieved_ids = [doc['id'] for doc in retrieved]
+                relevant_retrieved = len(set(retrieved_ids) & set(relevant_ids))
+                precision = relevant_retrieved / 5
+                results[name].append(precision)
+
+        summary = {}
+        for name, precisions in results.items():
+            summary[name] = {
+                "avg_precision": sum(precisions) / len(precisions),
+                "min": min(precisions),
+                "max": max(precisions)
+            }
+        return summary
+
+# Usage
+comparison = RetrievalComparison()
+comparison.add_strategy("basic", lambda q, top_k: basic_rag.retrieve(q, top_k))
+comparison.add_strategy("reranked", lambda q, top_k: reranked_rag.retrieve(q, top_k))
+comparison.add_strategy("hybrid", lambda q, top_k: hybrid_rag.retrieve(q, top_k))
+
+results = comparison.compare(test_queries)
+
+for strategy, metrics in results.items():
+    print(f"{strategy}: Avg P@5={metrics['avg_precision']:.2f} "
+          f"(range: {metrics['min']:.2f}-{metrics['max']:.2f})")
+```
+
+When comparing strategies, it's important to check whether differences are statistically significant, not just noise. A paired t-test is the standard approach:
+
+```python
+from scipy import stats
+
+def is_significantly_better(scores_a, scores_b, alpha=0.05):
+    """Check if strategy A is significantly better than strategy B."""
+    t_stat, p_value = stats.ttest_rel(scores_a, scores_b)
+    return (p_value < alpha and t_stat > 0), p_value
+```
+
+If the p-value is below 0.05, you can be 95% confident that the difference is real, not a fluke of your test set. For production changes, always test on held-out queries — not the ones you used to tune your system.
+
+::::challenge{id=m3-05-evaluation title="Build a Complete Evaluation Pipeline"}
+
+Starting from your RAG system, build an evaluation pipeline and use it to measure the impact of each optimisation technique you've learned in this module.
+
+**Step 1: Create a test dataset.** Write at least 20 (query, relevant document) pairs for your corpus. Include a mix of simple factual questions, questions that use different phrasing from the documents, and complex multi-part questions.
+
+**Step 2: Measure your baseline.** Evaluate your Module 2 basic RAG system on the test dataset. Record Precision@5, Recall@5, and MRR.
+
+**Step 3: Add improvements one at a time.** After each improvement (query expansion, re-ranking, hybrid search, caching), re-evaluate on the same test dataset. Record the metrics and the average response latency.
+
+**Step 4: Produce a comparison report.** Your report should look something like this:
+
+```
+Strategy         P@5    MRR    Avg Latency
+──────────────────────────────────────────
+Basic RAG        0.62   0.71   850ms
++ Expansion      0.71   0.78   1200ms
++ Re-ranking     0.79   0.85   1450ms
++ Hybrid         0.81   0.87   1100ms
++ Cache (avg)    0.81   0.87   320ms
+```
+
+Think about the trade-offs. Re-ranking improved precision by 0.08 but added 250ms of latency — is that worth it for your application? Caching didn't improve precision at all but cut average latency by 75% — is that the right investment? These are the kinds of engineering decisions you'll make constantly in production.
+::::
+
+::::challenge{id=m3-05-checkpoint title="Project Checkpoint 3: Optimise Your RAG System"}
+
+Enhance your capstone project with at least two of the advanced techniques from this module. Create an evaluation test set of at least 20 queries and measure the impact of each optimisation.
+
+Your deliverables should include:
+
+- Implementation of at least two advanced techniques (query expansion, re-ranking, hybrid search, or semantic caching)
+- An evaluation test dataset (20+ queries with expected retrieval targets)
+- A comparison report documenting baseline metrics, metrics after each optimisation, latency and cost analysis, and your recommendation for which techniques to deploy and why
+
+This checkpoint mirrors the work of a production ML engineer: implement improvements, measure their impact, and make data-driven recommendations.
+::::
+
+## Summary and What's Next
+
+In this module, you've learned how to take a basic RAG system and make it production-grade. Agentic RAG handles complex and ambiguous queries through query expansion and decomposition. Re-ranking improves precision by using cross-encoders to refine vector search results. Hybrid search combines the semantic understanding of dense retrieval with the exact-matching power of BM25. Knowledge graphs complement vector search with structured relationship reasoning. Semantic caching reduces cost and latency by serving similar queries from cache. And retrieval evaluation gives you the metrics to make informed decisions about which techniques to use.
+
+In Module 4, we turn our attention to conversation management. Long conversations quickly consume your context window, and naive approaches — like sending the entire history with every message — become expensive and eventually hit token limits. You'll learn sophisticated strategies for summarising conversation history, selectively retaining important context, implementing retrieval-based memory, and personalising responses based on what the chatbot has learned about the user over time.
+
+## Additional Resources
+
+- ["Lost in the Middle: How Language Models Use Long Contexts"](https://arxiv.org/abs/2307.03172) (Liu et al., 2023) — Important findings on how LLMs use context window position
+- ["Precise Zero-Shot Dense Retrieval without Relevance Labels"](https://arxiv.org/abs/2212.10496) (Gao et al., 2021) — Foundational work on dense retrieval
+- [Pinecone Blog: "Hybrid Search Explained"](https://www.pinecone.io/learn/hybrid-search-intro/) — Practical guide to combining dense and sparse search
+- [sentence-transformers](https://www.sbert.net/) — Library for cross-encoder re-ranking models
+- [rank-bm25](https://github.com/dorianbrown/rank_bm25) — BM25 implementation for Python
+- [NetworkX](https://networkx.org/) — Graph manipulation library
+- [ragas](https://github.com/explodinggradients/ragas) — RAG evaluation framework
+
+## Hands-on practical
+
+Work through the accompanying notebook: [`module_3/05-evaluating-and-optimising-retrieval.ipynb`](https://github.com/OxfordCompetencyCenters/aicc_chatbot_modules/blob/main/module_3/05-evaluating-and-optimising-retrieval.ipynb). It walks through a tiny labelled test set, Precision@K / Recall@K / MRR implemented from scratch, and a comparison framework that evaluates basic vs query-expanded retrieval.

--- a/technology_and_tooling/chatbot_development/m4-01-conversation-history-management.md
+++ b/technology_and_tooling/chatbot_development/m4-01-conversation-history-management.md
@@ -1,0 +1,145 @@
+---
+name: Conversation History Management
+dependsOn:
+  - technology_and_tooling.chatbot_development.m3-05-evaluating-and-optimising-retrieval
+tags: [chatbots, memory, context-management]
+learningOutcomes:
+  - Distinguish between short-term and long-term memory in conversational AI.
+  - Explain why unbounded conversation history is unsustainable in production.
+  - Implement fixed-window and token-based window management strategies.
+  - Understand the trade-offs between simplicity and context preservation.
+attribution:
+  - citation: >
+      Oxford AI Competency Centre (2026). Chatbot Development Course.
+    url: https://github.com/OxfordCompetencyCenters/aicc_chatbot_modules
+    license: CC-BY-4.0
+---
+
+In Module 1, you built a stateful chatbot that appends every message to a growing history list and sends the whole thing with every API call. That approach works for short conversations, but it's unsustainable. Real-world chatbot sessions — customer support troubleshooting, multi-day tutoring, personal assistant interactions — can span dozens or hundreds of turns. Without intelligent management, the conversation history grows until it exceeds the context window, at which point the system either crashes or silently drops messages. This module introduces the strategies that production chatbots use to handle conversations of any length.
+
+## Short-Term vs Long-Term Memory
+
+It helps to think about chatbot memory in the same terms we use for human memory. **Short-term memory** (or working memory) is the information that's immediately available — the last few turns of conversation, the current topic, what the user just said. In chatbot terms, this is whatever fits in the LLM's context window. It's fast to access (it's already in the prompt) but limited in capacity.
+
+**Long-term memory** is everything else — past conversation sessions, user preferences, decisions made weeks ago. In chatbot terms, this information lives in a database or vector store and must be explicitly retrieved when it's needed. It's unlimited in capacity but requires a retrieval step to access.
+
+Consider a customer support scenario. Short-term memory lets the bot follow the current troubleshooting thread: the user described an error, the bot asked for details, the user provided a stack trace. Long-term memory lets the bot recall that this same user had a similar issue last month and the fix was to update a configuration file.
+
+The challenge is bridging these two layers. Short-term memory fits naturally in the context window, but long-term memory doesn't. We need strategies to decide what goes into the context window on each turn, how to compress older information, and when to retrieve from long-term storage. The rest of this module builds those strategies.
+
+## The Context Window Problem
+
+To see why this matters, let's trace the token usage of a customer support conversation using GPT-3.5-turbo with an 8,000-token context window.
+
+```
+Turn 1:  System prompt (200) + User (50) + Response (150)    = 400 tokens
+Turn 5:  System + History (1,500) + New turn (200)           = 1,700 tokens
+Turn 10: System + History (4,000) + New turn (200)           = 4,200 tokens
+Turn 20: System + History (9,500) + New turn (200)           = 9,700 tokens
+```
+
+By turn 20, the conversation has blown past the 8,000-token limit. Even with GPT-4-turbo's 128K context window, a particularly detailed conversation can still hit limits — and you're paying for every token in every request. A 50-turn conversation where you send the full history on every call is sending roughly 25,000 tokens per request by the end, which is expensive and slow.
+
+The real cost isn't just financial. When the context window fills up, the bot can't process new messages without dropping old ones. If it drops them blindly, critical context is lost. A user who established important information at the start of the conversation — "I'm on version 2.3, running Windows, with a premium account" — finds that the bot has forgotten all of it by turn 15.
+
+## Fixed-Window Management
+
+The simplest strategy is to keep only the most recent N messages. Old messages are dropped entirely as new ones arrive.
+
+```python
+class FixedWindowChatbot:
+    def __init__(self, system_prompt, window_size=10):
+        self.system_prompt = system_prompt
+        self.window_size = window_size
+        self.conversation_history = []
+
+    def chat(self, user_message):
+        self.conversation_history.append({
+            "role": "user",
+            "content": user_message
+        })
+
+        # Keep only the most recent N messages
+        if len(self.conversation_history) > self.window_size:
+            self.conversation_history = self.conversation_history[-self.window_size:]
+
+        # Build the prompt
+        messages = [
+            {"role": "system", "content": self.system_prompt}
+        ] + self.conversation_history
+
+        response = openai.ChatCompletion.create(
+            model="gpt-3.5-turbo",
+            messages=messages
+        )
+
+        assistant_message = response.choices[0].message.content
+        self.conversation_history.append({
+            "role": "assistant",
+            "content": assistant_message
+        })
+
+        return assistant_message
+```
+
+This is simple and guarantees you'll never exceed the context window. But it has a significant flaw: the forgetting is abrupt and indiscriminate. Message 11 disappears the moment message 12 arrives, regardless of whether message 11 contained critical information. A user's account ID, stated in message 3, is gone by the time you reach message 14.
+
+## Token-Based Window Management
+
+A refinement is to manage the window by token count rather than message count. This accounts for the fact that messages vary in length — a one-word acknowledgement costs fewer tokens than a detailed error description.
+
+```python
+import tiktoken
+
+class TokenWindowChatbot:
+    def __init__(self, system_prompt, max_tokens=2000):
+        self.system_prompt = system_prompt
+        self.max_tokens = max_tokens
+        self.conversation_history = []
+        self.encoding = tiktoken.encoding_for_model("gpt-3.5-turbo")
+
+    def count_tokens(self, messages):
+        total = 0
+        for message in messages:
+            total += len(self.encoding.encode(message["content"]))
+        return total
+
+    def chat(self, user_message):
+        self.conversation_history.append({
+            "role": "user",
+            "content": user_message
+        })
+
+        # Prune oldest message pairs until under budget
+        while self.count_tokens(self.conversation_history) > self.max_tokens:
+            if len(self.conversation_history) > 2:
+                self.conversation_history.pop(0)
+                self.conversation_history.pop(0)
+            else:
+                break
+
+        messages = [
+            {"role": "system", "content": self.system_prompt}
+        ] + self.conversation_history
+
+        response = openai.ChatCompletion.create(
+            model="gpt-3.5-turbo",
+            messages=messages
+        )
+
+        assistant_message = response.choices[0].message.content
+        self.conversation_history.append({
+            "role": "assistant",
+            "content": assistant_message
+        })
+
+        return assistant_message
+```
+
+Token-based pruning adapts to message length — a conversation with short messages keeps more turns in memory than one with long messages. But it still suffers from the same fundamental problem: it treats all messages as equally important. A one-word "Thanks!" consumes a trivial number of tokens but occupies a slot that could be used by critical context.
+
+Both window strategies are useful as building blocks. In the following sections, we'll layer smarter techniques on top — summarisation, selective memory, and retrieval-based memory — that preserve important information even as conversations grow beyond the window size.
+
+## Hands-on practical
+
+Work through the accompanying notebook: [`module_4/01-conversation-history-management.ipynb`](https://github.com/OxfordCompetencyCenters/aicc_chatbot_modules/blob/main/module_4/01-conversation-history-management.ipynb). It walks through simulating an unbounded-history chatbot, a fixed-window variant, and a token-window variant — with an account-number recall test that shows how each one forgets.

--- a/technology_and_tooling/chatbot_development/m4-01-conversation-history-management.md
+++ b/technology_and_tooling/chatbot_development/m4-01-conversation-history-management.md
@@ -12,6 +12,7 @@ attribution:
   - citation: >
       Oxford AI Competency Centre (2026). Chatbot Development Course.
     url: https://github.com/OxfordCompetencyCenters/aicc_chatbot_modules
+    image: https://github.com/OxfordCompetencyCenters.png
     license: CC-BY-4.0
 ---
 

--- a/technology_and_tooling/chatbot_development/m4-02-conversation-summarisation.md
+++ b/technology_and_tooling/chatbot_development/m4-02-conversation-summarisation.md
@@ -1,0 +1,209 @@
+---
+name: Conversation Summarisation
+dependsOn:
+  - technology_and_tooling.chatbot_development.m4-01-conversation-history-management
+tags: [chatbots, memory, summarisation]
+learningOutcomes:
+  - Implement rolling summarisation to compress older conversation turns.
+  - Build a hierarchical memory system for very long conversations.
+  - Understand the trade-offs between summarisation fidelity and token savings.
+attribution:
+  - citation: >
+      Oxford AI Competency Centre (2026). Chatbot Development Course.
+    url: https://github.com/OxfordCompetencyCenters/aicc_chatbot_modules
+    license: CC-BY-4.0
+---
+
+Window strategies drop old messages entirely. Summarisation offers a better alternative: instead of forgetting older parts of the conversation, compress them into a concise summary that captures the key points. This preserves context at a fraction of the token cost.
+
+## Rolling Summarisation
+
+The idea is straightforward. Keep the most recent messages in full detail — these are the active part of the conversation. When the history grows beyond a threshold, take the older messages, generate a summary, and replace them with that summary. The summary lives at the beginning of the context, giving the LLM awareness of what was discussed earlier without the full verbatim history.
+
+Consider a 20-turn customer support conversation about email notifications. The full history might consume 3,000 tokens. A summary of the first 14 turns might read: "User is setting up email notifications on version 2.3. After trying Settings > Notifications (not available in 2.3), we directed them to Preferences > Email. User successfully configured notifications but had a question about frequency settings." That's roughly 200 tokens — a 10–15x compression.
+
+Here's a complete implementation:
+
+```python
+class SummarizingChatbot:
+    def __init__(self, system_prompt, summary_threshold=10):
+        self.system_prompt = system_prompt
+        self.conversation_summary = ""
+        self.recent_messages = []
+        self.summary_threshold = summary_threshold
+
+    def summarize_conversation(self, messages):
+        """Generate a concise summary of a set of messages."""
+        conversation_text = "\n".join([
+            f"{msg['role']}: {msg['content']}"
+            for msg in messages
+        ])
+
+        summary_prompt = f"""Summarize the key points of this conversation concisely.
+Focus on:
+- Main topics discussed
+- Important facts or decisions
+- Current state of the conversation
+
+Conversation:
+{conversation_text}
+
+Summary (2-3 sentences):"""
+
+        response = openai.ChatCompletion.create(
+            model="gpt-3.5-turbo",
+            messages=[{"role": "user", "content": summary_prompt}],
+            temperature=0.3,
+            max_tokens=150
+        )
+
+        return response.choices[0].message.content
+
+    def chat(self, user_message):
+        self.recent_messages.append({
+            "role": "user",
+            "content": user_message
+        })
+
+        # When recent messages exceed the threshold, summarise the older half
+        if len(self.recent_messages) > self.summary_threshold * 2:
+            to_summarize = self.recent_messages[:self.summary_threshold]
+            self.recent_messages = self.recent_messages[self.summary_threshold:]
+
+            new_summary = self.summarize_conversation(to_summarize)
+
+            if self.conversation_summary:
+                self.conversation_summary += f"\n\n{new_summary}"
+            else:
+                self.conversation_summary = new_summary
+
+        # Build the prompt
+        messages = [{"role": "system", "content": self.system_prompt}]
+
+        if self.conversation_summary:
+            messages.append({
+                "role": "system",
+                "content": f"Conversation summary so far:\n{self.conversation_summary}"
+            })
+
+        messages.extend(self.recent_messages)
+
+        response = openai.ChatCompletion.create(
+            model="gpt-3.5-turbo",
+            messages=messages
+        )
+
+        assistant_message = response.choices[0].message.content
+        self.recent_messages.append({
+            "role": "assistant",
+            "content": assistant_message
+        })
+
+        return assistant_message
+```
+
+The `summary_threshold` controls how often summarisation happens. With a threshold of 10, every 10 messages the oldest messages are compressed into a summary. The summary accumulates as the conversation continues, but it grows slowly — a few hundred tokens per cycle — compared to the thousands of tokens that the full history would consume.
+
+Each summarisation costs one additional API call, but it pays for itself quickly. Without summarisation, a 30-turn conversation might send 5,000+ tokens per request. With summarisation, the total context stays around 2,000–2,500 tokens: roughly 600 tokens of accumulated summary plus 1,500 tokens of recent messages. That's less than half the cost on every subsequent request.
+
+The trade-off is lossy compression. The summary captures key facts and decisions but loses the exact wording, nuances, and the back-and-forth of the conversation. If the user says "Go back to what you said third — the one about environment variables", the summarised context may not retain enough detail to know what "third" refers to. For most practical purposes, this level of detail loss is acceptable. For use cases that require verbatim recall, combine summarisation with retrieval-based memory (covered in Section 4).
+
+## Hierarchical Summarisation
+
+In very long conversations (100+ turns), even summaries accumulate. A flat summary that grows every 10 turns will eventually consume thousands of tokens itself. Hierarchical summarisation solves this by applying multiple levels of compression, similar to how a computer's memory hierarchy works.
+
+```
+Level 0 (Current):  Last 5 turns in full detail        ~500 tokens
+Level 1 (Recent):   Summary of turns 6–20              ~200 tokens
+Level 2 (Medium):   Summary of turns 21–50             ~100 tokens
+Level 3 (Distant):  Summary of turns 51–100            ~50 tokens
+```
+
+As information ages, it gets progressively more compressed. The most recent turns are stored verbatim. Slightly older turns are summarised. Even older turns have their summaries summarised — a "summary of summaries". The earliest parts of the conversation are reduced to just the essential facts.
+
+```python
+class HierarchicalMemory:
+    def __init__(self):
+        self.current_window = []     # Last 5 turns, full detail
+        self.level1_summary = ""     # Turns 6–20
+        self.level2_summary = ""     # Turns 21–50
+        self.level3_summary = ""     # Turns 51+
+
+    def add_turn(self, user_msg, assistant_msg):
+        self.current_window.extend([
+            {"role": "user", "content": user_msg},
+            {"role": "assistant", "content": assistant_msg}
+        ])
+
+        # Promote from current window to level 1
+        if len(self.current_window) > 10:
+            to_summarize = self.current_window[:6]
+            self.current_window = self.current_window[6:]
+
+            summary = self.summarize(to_summarize)
+
+            # If level 1 is getting long, promote to level 2
+            if len(self.level1_summary) > 500:
+                self.level2_summary = self.summarize_summaries(
+                    [self.level2_summary, self.level1_summary]
+                )
+                self.level1_summary = summary
+            else:
+                self.level1_summary += f"\n{summary}"
+
+    def build_context(self):
+        """Assemble the full context from all memory layers."""
+        context_parts = []
+
+        if self.level3_summary:
+            context_parts.append(f"Early conversation: {self.level3_summary}")
+        if self.level2_summary:
+            context_parts.append(f"Previous discussion: {self.level2_summary}")
+        if self.level1_summary:
+            context_parts.append(f"Recent context: {self.level1_summary}")
+
+        context_parts.append("Current conversation:")
+        context_parts.extend([
+            f"{msg['role']}: {msg['content']}"
+            for msg in self.current_window
+        ])
+
+        return "\n\n".join(context_parts)
+```
+
+To see the impact, compare token usage at turn 100 across different strategies:
+
+```
+No memory management:        Exceeds context limit at turn ~20
+Fixed window (10 messages):  2,000 tokens — but lost everything before turn 90
+Flat summarisation:          3,500 tokens — growing
+Hierarchical summarisation:  1,800 tokens — bounded, retains all context
+```
+
+The hierarchical approach keeps token usage bounded regardless of conversation length. A 100-turn conversation might use: 500 tokens for the current window, 200 tokens for level 1, 100 tokens for level 2, and 50 tokens for level 3 — roughly 850 tokens of context total. The bot can still reference information from turn 1, just in highly condensed form.
+
+The right number of hierarchy levels and the promotion thresholds depend on your use case. For most applications, two or three levels are sufficient. Customer support conversations rarely exceed 50 turns, so flat summarisation with a threshold of 10 works well. Tutoring sessions that span hours might benefit from a three-level hierarchy. Personal assistants that operate over weeks or months might need four levels plus retrieval-based memory.
+
+::::challenge{id=m4-02-compare title="Implement and Compare Summarisation Strategies"}
+
+Build both a flat summarising chatbot and a hierarchical memory system, then test them with a 30-turn conversation.
+
+```python
+# Flat summarisation
+bot_flat = SummarizingChatbot(system_prompt="You are a helpful assistant.", summary_threshold=10)
+
+# Run 30 turns
+for i in range(30):
+    response = bot_flat.chat(f"This is turn {i+1}. Tell me about topic {i+1}.")
+    tokens = bot_flat.get_token_count()
+    print(f"Turn {i+1}: {tokens} tokens")
+```
+
+Test recall by asking the bot about information from early turns. After 30 turns, does the bot remember what was discussed at turn 5? At turn 1? How does the quality of recall differ between flat summarisation and the hierarchical approach?
+
+A particularly revealing test: at turn 1, tell the bot "My account ID is ABC123." Then, at turn 25, ask "What is my account ID?" Does the summary preserve this specific fact? If not, how could you ensure it does? (The next section on selective memory addresses this question directly.)
+::::
+
+## Hands-on practical
+
+Work through the accompanying notebook: [`module_4/02-conversation-summarisation.ipynb`](https://github.com/OxfordCompetencyCenters/aicc_chatbot_modules/blob/main/module_4/02-conversation-summarisation.ipynb). It walks through summarising a block of turns, building a rolling-summary chatbot, and running the account-number recall test.

--- a/technology_and_tooling/chatbot_development/m4-02-conversation-summarisation.md
+++ b/technology_and_tooling/chatbot_development/m4-02-conversation-summarisation.md
@@ -11,6 +11,7 @@ attribution:
   - citation: >
       Oxford AI Competency Centre (2026). Chatbot Development Course.
     url: https://github.com/OxfordCompetencyCenters/aicc_chatbot_modules
+    image: https://github.com/OxfordCompetencyCenters.png
     license: CC-BY-4.0
 ---
 

--- a/technology_and_tooling/chatbot_development/m4-03-selective-memory.md
+++ b/technology_and_tooling/chatbot_development/m4-03-selective-memory.md
@@ -1,7 +1,7 @@
 ---
 name: Selective Memory
 dependsOn:
-  - technology_and_tooling.chatbot_development.m4-02-conversation-summarisation
+  - technology_and_tooling.chatbot_development.m4-01-conversation-history-management
 tags: [chatbots, memory, context-management]
 learningOutcomes:
   - Score message importance using both LLM-based and heuristic approaches.

--- a/technology_and_tooling/chatbot_development/m4-03-selective-memory.md
+++ b/technology_and_tooling/chatbot_development/m4-03-selective-memory.md
@@ -11,6 +11,7 @@ attribution:
   - citation: >
       Oxford AI Competency Centre (2026). Chatbot Development Course.
     url: https://github.com/OxfordCompetencyCenters/aicc_chatbot_modules
+    image: https://github.com/OxfordCompetencyCenters.png
     license: CC-BY-4.0
 ---
 

--- a/technology_and_tooling/chatbot_development/m4-03-selective-memory.md
+++ b/technology_and_tooling/chatbot_development/m4-03-selective-memory.md
@@ -1,0 +1,187 @@
+---
+name: Selective Memory
+dependsOn:
+  - technology_and_tooling.chatbot_development.m4-02-conversation-summarisation
+tags: [chatbots, memory, context-management]
+learningOutcomes:
+  - Score message importance using both LLM-based and heuristic approaches.
+  - Implement selective pruning that drops low-importance messages first.
+  - Combine importance scoring with summarisation for optimal context management.
+attribution:
+  - citation: >
+      Oxford AI Competency Centre (2026). Chatbot Development Course.
+    url: https://github.com/OxfordCompetencyCenters/aicc_chatbot_modules
+    license: CC-BY-4.0
+---
+
+Window strategies and summarisation treat all messages as equally important. But in any conversation, some messages carry critical information — account IDs, error codes, deadlines, decisions — while others are filler: "Thanks!", "OK, sure", "Let me think about that." When you need to free up token budget, it makes far more sense to drop the filler first and preserve the critical facts.
+
+## Scoring Message Importance
+
+There are two approaches to importance scoring: using an LLM for nuanced assessment, or using rule-based heuristics for speed and cost.
+
+The LLM-based approach asks the model to rate each message's importance on a scale:
+
+```python
+def score_message_importance(message):
+    """Use an LLM to rate importance from 1-10."""
+    prompt = f"""Rate the importance of this message for maintaining conversation context.
+Score from 1-10 where:
+1-3: Pleasantries, filler, not critical
+4-6: Relevant but not essential
+7-10: Critical facts, decisions, or information that must be retained
+
+Message: {message}
+
+Score (just the number):"""
+
+    response = openai.ChatCompletion.create(
+        model="gpt-3.5-turbo",
+        messages=[{"role": "user", "content": prompt}],
+        temperature=0.0,
+        max_tokens=5
+    )
+
+    try:
+        score = int(response.choices[0].message.content.strip())
+        return max(1, min(10, score))
+    except:
+        return 5
+```
+
+This is accurate but expensive — it requires an API call for every message. For high-volume production systems, heuristic scoring is more practical:
+
+```python
+import re
+
+def score_message_heuristic(message):
+    """Rule-based importance scoring — fast and free."""
+    score = 5
+
+    # Indicators of high importance
+    high_patterns = [
+        r'\b(account|id|number|email|phone)\b',
+        r'\b(ticket|order|reference)\s*#?\d+',
+        r'\b(deadline|urgent|critical|asap)\b',
+        r'\b(password|security|privacy)\b',
+        r'\b(error|bug|issue|problem)\b',
+        r'^\d+[.:]',  # Numbered steps
+    ]
+
+    # Indicators of low importance
+    low_patterns = [
+        r'^(thanks?|thx|ty|thank you)',
+        r'^(ok|okay|sure|yes|no)$',
+        r'^(hi|hello|hey)',
+        r'(lol|haha|hmm)',
+    ]
+
+    for pattern in high_patterns:
+        if re.search(pattern, message, re.IGNORECASE):
+            score += 2
+
+    for pattern in low_patterns:
+        if re.search(pattern, message, re.IGNORECASE):
+            score -= 2
+
+    if len(message.split()) > 30:
+        score += 1  # Longer messages tend to be more substantive
+
+    return max(1, min(10, score))
+```
+
+Heuristic scoring works surprisingly well in practice. Messages containing account numbers, error codes, and deadlines almost always score high. Greetings, one-word acknowledgements, and filler expressions score low. The rules can be customised for your domain — a medical chatbot might add high-importance patterns for symptoms and medications, while an e-commerce bot might flag order numbers and shipping addresses.
+
+## Selective Pruning
+
+With importance scores attached to each message, pruning becomes intelligent. Instead of dropping the oldest messages, drop the least important ones:
+
+```python
+class SelectiveMemoryChatbot:
+    def __init__(self, system_prompt, max_tokens=2000):
+        self.system_prompt = system_prompt
+        self.max_tokens = max_tokens
+        self.conversation = []
+        self.encoding = tiktoken.encoding_for_model("gpt-3.5-turbo")
+
+    def chat(self, user_message):
+        importance = score_message_heuristic(user_message)
+
+        self.conversation.append({
+            "role": "user",
+            "content": user_message,
+            "importance": importance
+        })
+
+        self._prune_by_importance()
+
+        # Build messages for the API (without the importance field)
+        messages = [{"role": "system", "content": self.system_prompt}]
+        messages += [{"role": msg["role"], "content": msg["content"]}
+                     for msg in self.conversation]
+
+        response = openai.ChatCompletion.create(
+            model="gpt-3.5-turbo",
+            messages=messages
+        )
+
+        assistant_message = response.choices[0].message.content
+        assistant_importance = score_message_heuristic(assistant_message)
+
+        self.conversation.append({
+            "role": "assistant",
+            "content": assistant_message,
+            "importance": assistant_importance
+        })
+
+        self._prune_by_importance()
+        return assistant_message
+
+    def _prune_by_importance(self):
+        """Remove the least important messages to stay under the token budget."""
+        while self._count_tokens() > self.max_tokens:
+            if len(self.conversation) <= 2:
+                break
+
+            # Find the least important message, excluding the most recent pair
+            prunable = self.conversation[:-2]
+            if not prunable:
+                break
+
+            least_important = min(prunable, key=lambda x: x["importance"])
+            idx = self.conversation.index(least_important)
+
+            # Remove the message and its pair (user + assistant go together)
+            if least_important["role"] == "user" and idx + 1 < len(self.conversation):
+                self.conversation.pop(idx)
+                self.conversation.pop(idx)  # The assistant reply shifts down
+            elif least_important["role"] == "assistant" and idx > 0:
+                self.conversation.pop(idx)
+                self.conversation.pop(idx - 1)  # The preceding user message
+            else:
+                self.conversation.pop(idx)
+
+    def _count_tokens(self):
+        return sum(len(self.encoding.encode(msg["content"])) for msg in self.conversation)
+```
+
+The effect is dramatic. In a 30-turn customer support conversation, the messages "Thanks!", "OK", "Sure, go ahead", and "Hmm, let me think" are dropped first. Meanwhile, "My account ID is ABC123", "I'm getting error code 500", and "I need this resolved by Friday" are preserved even as the conversation grows far beyond the token budget.
+
+## Combining Strategies
+
+In practice, the best results come from combining selective memory with summarisation. Use importance scoring to decide what to keep in full and what to summarise. High-importance messages stay verbatim in the context. Low-importance messages get summarised or dropped entirely. Medium-importance messages get included in summaries.
+
+This gives you the best of both worlds: critical facts are always available in their exact form, while the general flow and context of the conversation is preserved through summaries. The token budget is used efficiently because it's allocated to the information that matters most.
+
+The architecture looks like this:
+
+1. Score every incoming message for importance.
+2. Always keep the most recent 3–5 turns in full (regardless of importance — they're the active conversation).
+3. For older messages, keep high-importance messages verbatim and summarise the rest.
+4. When the token budget is tight, drop the low-importance messages entirely before touching the summaries or high-importance messages.
+
+This is the approach used by production chatbot systems that need to handle extended conversations without losing critical context. In the next section, we'll add another layer: retrieval-based memory that lets the bot access information from any point in the conversation history, even across sessions.
+
+## Hands-on practical
+
+Work through the accompanying notebook: [`module_4/03-selective-memory.ipynb`](https://github.com/OxfordCompetencyCenters/aicc_chatbot_modules/blob/main/module_4/03-selective-memory.ipynb). It walks through heuristic importance scoring, an LLM-based scorer, and a `SelectiveMemoryChatbot` that prunes the lowest-importance messages first.

--- a/technology_and_tooling/chatbot_development/m4-04-retrieval-based-memory.md
+++ b/technology_and_tooling/chatbot_development/m4-04-retrieval-based-memory.md
@@ -1,7 +1,7 @@
 ---
 name: Retrieval-Based Memory
 dependsOn:
-  - technology_and_tooling.chatbot_development.m4-03-selective-memory
+  - technology_and_tooling.chatbot_development.m4-01-conversation-history-management
 tags: [chatbots, memory, retrieval, vector-search]
 learningOutcomes:
   - Store conversation turns as vector embeddings for long-term retrieval.

--- a/technology_and_tooling/chatbot_development/m4-04-retrieval-based-memory.md
+++ b/technology_and_tooling/chatbot_development/m4-04-retrieval-based-memory.md
@@ -1,0 +1,264 @@
+---
+name: Retrieval-Based Memory
+dependsOn:
+  - technology_and_tooling.chatbot_development.m4-03-selective-memory
+tags: [chatbots, memory, retrieval, vector-search]
+learningOutcomes:
+  - Store conversation turns as vector embeddings for long-term retrieval.
+  - Implement cross-session memory that persists between conversations.
+  - Design a hybrid memory architecture that combines windowing, summarisation, retrieval, and user profiles.
+attribution:
+  - citation: >
+      Oxford AI Competency Centre (2026). Chatbot Development Course.
+    url: https://github.com/OxfordCompetencyCenters/aicc_chatbot_modules
+    license: CC-BY-4.0
+---
+
+Window management, summarisation, and selective pruning all operate within a single session. Once the user closes the chat and opens a new one, the context is gone. The bot has no way to recall what was discussed yesterday, last week, or in any previous session. For many applications — customer support, tutoring, personal assistants — this is a serious limitation. Users expect continuity. They don't want to re-explain their setup, re-state their preferences, or re-describe the problem they've been troubleshooting across multiple sessions.
+
+Retrieval-based memory solves this by treating conversation history the same way RAG treats documents. Every conversation turn is embedded and stored in a vector database. When the user sends a new message, the system searches those stored embeddings for semantically relevant past turns and injects them into the context. The bot can "remember" something from any point in its history with a user, even if that information was exchanged weeks ago.
+
+## Storing and Retrieving Past Conversations
+
+The concept is straightforward if you've already built a RAG system. Instead of embedding document chunks, you embed conversation turns. Instead of retrieving documents relevant to a user's question, you retrieve past conversation turns relevant to the current message. The mechanics are identical — the only difference is what you're storing.
+
+Consider a user who discussed a deployment issue with your bot three days ago. Today they return and ask, "What was that deployment issue we discussed?" Without retrieval-based memory, the bot has no idea — it has no access to previous sessions. With retrieval-based memory, the system embeds the user's question, searches all past conversation embeddings, finds the turn from three days ago where the user said "Deployment failing due to missing env var," and includes that context in the prompt. The bot can then respond: "We discussed a deployment issue where an environment variable was missing."
+
+This approach has several advantages over the strategies covered so far. It is not limited by the context window, since stored turns live in a database that can hold millions of entries. It works across sessions, because the vector database persists between conversations. It retrieves selectively, pulling in only the turns that are relevant to the current question rather than dumping the entire history into the prompt. And it enables personalisation, since the system can retrieve past preferences, decisions, and context about the user.
+
+Here is a complete implementation using ChromaDB:
+
+```python
+import chromadb
+import openai
+from datetime import datetime
+
+class ConversationalMemory:
+    def __init__(self, user_id):
+        self.user_id = user_id
+        self.client = chromadb.PersistentClient(path="./conversation_memory")
+        self.collection = self.client.get_or_create_collection(
+            f"user_{user_id}_conversations"
+        )
+        self.current_session = []
+        self.turn_counter = 0
+
+    def store_turn(self, role, content):
+        """Store a conversation turn in vector memory."""
+        self.turn_counter += 1
+
+        response = openai.Embedding.create(
+            model="text-embedding-3-small",
+            input=content
+        )
+        embedding = response['data'][0]['embedding']
+
+        self.collection.add(
+            ids=[f"turn_{self.turn_counter}"],
+            embeddings=[embedding],
+            documents=[content],
+            metadatas=[{
+                "role": role,
+                "timestamp": datetime.now().isoformat(),
+                "turn": self.turn_counter,
+                "session_id": "current"
+            }]
+        )
+
+        self.current_session.append({
+            "role": role,
+            "content": content,
+            "turn": self.turn_counter
+        })
+
+    def retrieve_relevant_history(self, query, top_k=3):
+        """Retrieve relevant past conversation turns."""
+        response = openai.Embedding.create(
+            model="text-embedding-3-small",
+            input=query
+        )
+        query_embedding = response['data'][0]['embedding']
+
+        # Search past turns, excluding recent ones already in the current window
+        results = self.collection.query(
+            query_embeddings=[query_embedding],
+            n_results=top_k,
+            where={"turn": {"$lt": self.turn_counter - 10}}
+        )
+
+        relevant_turns = []
+        if results['documents'][0]:
+            for doc, meta in zip(results['documents'][0], results['metadatas'][0]):
+                relevant_turns.append({
+                    "content": doc,
+                    "role": meta['role'],
+                    "turn": meta['turn'],
+                    "timestamp": meta['timestamp']
+                })
+
+        return relevant_turns
+
+    def chat(self, user_message):
+        """Chat with retrieval-based memory."""
+        self.store_turn("user", user_message)
+
+        relevant_past = self.retrieve_relevant_history(user_message, top_k=3)
+
+        messages = [{"role": "system", "content": "You are a helpful assistant with memory of past conversations."}]
+
+        if relevant_past:
+            past_context = "Relevant past conversation:\n"
+            for turn in relevant_past:
+                past_context += f"[Turn {turn['turn']}] {turn['role']}: {turn['content']}\n"
+
+            messages.append({
+                "role": "system",
+                "content": past_context
+            })
+
+        # Add recent conversation (last 5 exchanges)
+        recent = self.current_session[-10:]
+        for turn in recent:
+            messages.append({
+                "role": turn["role"],
+                "content": turn["content"]
+            })
+
+        response = openai.ChatCompletion.create(
+            model="gpt-3.5-turbo",
+            messages=messages
+        )
+
+        assistant_message = response.choices[0].message.content
+        self.store_turn("assistant", assistant_message)
+
+        return assistant_message
+```
+
+The `store_turn` method embeds every message and saves it to ChromaDB with metadata including the role (user or assistant), timestamp, turn number, and session ID. The `retrieve_relevant_history` method embeds the current query and searches for semantically similar past turns, deliberately excluding the most recent turns (which are already in the current session window). The `chat` method ties everything together: it stores the user's message, retrieves relevant past context, builds the prompt with both retrieved history and recent turns, generates a response, and stores the assistant's reply.
+
+The cross-session capability is built into the design. Because ChromaDB uses persistent storage, the conversation history survives between sessions. When a user returns days later, a new `ConversationalMemory` instance for the same `user_id` connects to the same ChromaDB collection, giving it access to every past turn:
+
+```python
+# Day 1 conversation
+memory = ConversationalMemory(user_id="user_123")
+memory.chat("I'm working on a Python web app using Flask")
+memory.chat("I'm having trouble with database connections")
+# ... discussion about database issues ...
+
+# Day 3 conversation (new session, same user)
+memory2 = ConversationalMemory(user_id="user_123")
+response = memory2.chat("I'm back! Can you remind me what we discussed about databases?")
+# Bot retrieves turns from Day 1 and references them
+```
+
+The key insight is that retrieval-based memory doesn't include all past turns — that would be just as expensive as sending the full history. It includes only the turns that are semantically relevant to the current query. If the user asks about databases, turns about databases are retrieved. If the user asks about deployment, turns about deployment are retrieved. The token cost stays predictable: typically 3 retrieved turns at roughly 100 tokens each, adding about 300 tokens to the context regardless of how many thousands of turns are stored in the database.
+
+## Hybrid Memory Architecture
+
+Each of the memory strategies covered in this module has strengths and weaknesses. Window management is fast and simple but forgets everything outside the window. Summarisation preserves the general flow of conversation but loses specific details. Selective memory retains important facts but still operates within a single session. Retrieval-based memory accesses any past turn but adds the cost of an embedding API call on every turn.
+
+In production, the best results come from combining all four strategies into a layered architecture. Each layer serves a distinct purpose and has its own token budget:
+
+```
+Layer 1: Current Window (0-2 minutes)
+- Last 5 turns in full detail
+- Always included
+- ~500 tokens
+
+Layer 2: Recent Summary (2-15 minutes)
+- Rolling summary of turns 6-30
+- Updated every 5 turns
+- ~200 tokens
+
+Layer 3: Retrieved Memory (any time)
+- Top 3 relevant past turns
+- From vector search
+- ~300 tokens
+
+Layer 4: User Profile (persistent)
+- Key facts about user
+- Preferences, context
+- ~100 tokens
+
+Total: ~1,100 tokens for context
+```
+
+Layer 1 provides the immediate conversational context — the bot knows what was just said and can follow the thread of the current exchange. Layer 2 preserves awareness of the broader current session without consuming the token budget of the full history. Layer 3 reaches back into any point in the user's history, surfacing information from past sessions when it's relevant. Layer 4 provides persistent knowledge about the user that doesn't need to be retrieved because it's always relevant.
+
+Here is an implementation of this architecture:
+
+```python
+class HybridMemoryChatbot:
+    def __init__(self, user_id):
+        self.user_id = user_id
+        self.current_window = []                        # Layer 1
+        self.recent_summary = ""                        # Layer 2
+        self.memory = ConversationalMemory(user_id)     # Layer 3
+        self.user_profile = self.load_user_profile()    # Layer 4
+
+    def chat(self, user_message):
+        # Layer 1: Add to current window
+        self.current_window.append({"role": "user", "content": user_message})
+
+        # Keep only last 5 turns in the window
+        if len(self.current_window) > 10:
+            to_summarize = self.current_window[:6]
+            self.current_window = self.current_window[6:]
+
+            # Layer 2: Update summary
+            new_summary = self.summarize(to_summarize)
+            self.recent_summary = new_summary
+
+        # Layer 3: Retrieve relevant past turns
+        relevant_past = self.memory.retrieve_relevant_history(user_message)
+
+        # Build final context
+        messages = [{"role": "system", "content": "You are a helpful assistant."}]
+
+        # Add user profile (Layer 4)
+        if self.user_profile:
+            messages.append({
+                "role": "system",
+                "content": f"User context: {self.user_profile}"
+            })
+
+        # Add retrieved memory (Layer 3)
+        if relevant_past:
+            past_context = self.format_retrieved_memory(relevant_past)
+            messages.append({"role": "system", "content": past_context})
+
+        # Add recent summary (Layer 2)
+        if self.recent_summary:
+            messages.append({
+                "role": "system",
+                "content": f"Recent conversation: {self.recent_summary}"
+            })
+
+        # Add current window (Layer 1)
+        messages.extend(self.current_window)
+
+        # Generate response
+        response = openai.ChatCompletion.create(
+            model="gpt-3.5-turbo",
+            messages=messages
+        )
+
+        assistant_message = response.choices[0].message.content
+
+        # Update layers
+        self.current_window.append({"role": "assistant", "content": assistant_message})
+        self.memory.store_turn("assistant", assistant_message)
+
+        return assistant_message
+```
+
+The ordering of context in the prompt matters. The user profile comes first because it provides the broadest context. Retrieved memory comes next, giving the LLM awareness of relevant past interactions. The recent summary follows, providing continuity within the current session. The current window comes last, placing the active conversation — the most important context — closest to the generation point, where the LLM pays the most attention (as the "Lost in the Middle" research from Module 3 demonstrated).
+
+This architecture scales to conversations of any length while keeping total context around 1,100 tokens. A user can have a 200-turn conversation across multiple sessions spanning weeks, and the bot maintains coherent, contextual responses throughout. The token budget is bounded and predictable, making cost management straightforward.
+
+The right configuration of layers depends on your use case. Customer support bots might allocate more tokens to the current window (since the active troubleshooting thread is most important) and fewer to retrieved memory. Personal assistants might do the opposite, investing more in retrieval and user profiles to maintain long-term continuity. Tutoring bots might emphasise the summary layer to track the student's learning progression within a session. Experiment with the token allocations and the number of retrieved turns to find the balance that works best for your application.
+
+## Hands-on practical
+
+Work through the accompanying notebook: [`module_4/04-retrieval-based-memory.ipynb`](https://github.com/OxfordCompetencyCenters/aicc_chatbot_modules/blob/main/module_4/04-retrieval-based-memory.ipynb). It walks through a per-user ChromaDB conversation store, a chatbot that retrieves semantically relevant past turns, and a cross-session recall test.

--- a/technology_and_tooling/chatbot_development/m4-04-retrieval-based-memory.md
+++ b/technology_and_tooling/chatbot_development/m4-04-retrieval-based-memory.md
@@ -11,6 +11,7 @@ attribution:
   - citation: >
       Oxford AI Competency Centre (2026). Chatbot Development Course.
     url: https://github.com/OxfordCompetencyCenters/aicc_chatbot_modules
+    image: https://github.com/OxfordCompetencyCenters.png
     license: CC-BY-4.0
 ---
 

--- a/technology_and_tooling/chatbot_development/m4-05-user-personalisation.md
+++ b/technology_and_tooling/chatbot_development/m4-05-user-personalisation.md
@@ -1,7 +1,7 @@
 ---
 name: User Personalisation
 dependsOn:
-  - technology_and_tooling.chatbot_development.m4-04-retrieval-based-memory
+  - technology_and_tooling.chatbot_development.m4-01-conversation-history-management
 tags: [chatbots, memory, personalisation, user-profiles]
 learningOutcomes:
   - Extract user facts and preferences from conversation history using LLM-based analysis.

--- a/technology_and_tooling/chatbot_development/m4-05-user-personalisation.md
+++ b/technology_and_tooling/chatbot_development/m4-05-user-personalisation.md
@@ -11,6 +11,7 @@ attribution:
   - citation: >
       Oxford AI Competency Centre (2026). Chatbot Development Course.
     url: https://github.com/OxfordCompetencyCenters/aicc_chatbot_modules
+    image: https://github.com/OxfordCompetencyCenters.png
     license: CC-BY-4.0
 ---
 

--- a/technology_and_tooling/chatbot_development/m4-05-user-personalisation.md
+++ b/technology_and_tooling/chatbot_development/m4-05-user-personalisation.md
@@ -1,0 +1,314 @@
+---
+name: User Personalisation
+dependsOn:
+  - technology_and_tooling.chatbot_development.m4-04-retrieval-based-memory
+tags: [chatbots, memory, personalisation, user-profiles]
+learningOutcomes:
+  - Extract user facts and preferences from conversation history using LLM-based analysis.
+  - Build a persistent user profile system that accumulates knowledge across sessions.
+  - Integrate user profiles into chatbot responses for tailored interactions.
+attribution:
+  - citation: >
+      Oxford AI Competency Centre (2026). Chatbot Development Course.
+    url: https://github.com/OxfordCompetencyCenters/aicc_chatbot_modules
+    license: CC-BY-4.0
+---
+
+The memory strategies covered so far — windowing, summarisation, selective memory, and retrieval — all focus on preserving *what was said*. Personalisation goes a step further: it extracts and stores *who the user is*. Over the course of a conversation, users reveal a great deal about themselves. They mention their skill level, their preferences, their constraints, their goals. A beginner says "I'm new to programming." An expert says "I've been using Kubernetes for years." A user on Windows mentions compatibility concerns. A data scientist asks about pandas.
+
+A generic chatbot ignores all of this and gives the same response to every user. A personalised chatbot accumulates these facts into a user profile and uses them to tailor every subsequent response. The difference in user experience is substantial.
+
+## Extracting User Information
+
+The extraction process uses an LLM to analyse conversation history and pull out key facts about the user. The categories of information worth tracking include preferences ("I prefer Python over JavaScript"), context ("I'm a software engineer at a startup"), constraints ("I need solutions that work on Windows"), goals ("I'm learning machine learning"), and technical level (beginner, intermediate, expert).
+
+```python
+def extract_user_info(conversation_history):
+    """Extract key facts about the user from conversation history."""
+
+    conversation_text = "\n".join([
+        f"{msg['role']}: {msg['content']}"
+        for msg in conversation_history
+    ])
+
+    prompt = f"""From this conversation, extract key information about the user.
+Include: preferences, context about their situation, technical level, constraints, goals.
+
+Format as bullet points.
+
+Conversation:
+{conversation_text}
+
+User profile:"""
+
+    response = openai.ChatCompletion.create(
+        model="gpt-4",
+        messages=[{"role": "user", "content": prompt}],
+        temperature=0.0
+    )
+
+    return response.choices[0].message.content
+```
+
+This function takes a list of conversation messages and returns a structured summary of what the bot has learned about the user. Given a conversation where the user says "I'm a beginner learning Python for data science" and "I prefer using Jupyter notebooks," the extraction might produce:
+
+```
+User Profile:
+- Technical level: Beginner
+- Learning: Python
+- Goal: Data science
+- Preference: Jupyter notebooks
+- Context: New to programming
+```
+
+The extraction doesn't need to happen on every turn — that would be expensive. A practical approach is to run it periodically (every 10 turns) or at the end of each session. The extracted facts accumulate over time, building an increasingly detailed picture of the user.
+
+## Storing and Managing User Profiles
+
+The `UserProfileManager` class handles the persistence layer. In production, you'd store profiles in a database (PostgreSQL, MongoDB, or similar). For development and prototyping, a local JSON file per user works well:
+
+```python
+import json
+from datetime import datetime
+
+class UserProfileManager:
+    def __init__(self, user_id):
+        self.user_id = user_id
+        self.profile = self.load_profile()
+
+    def load_profile(self):
+        """Load user profile from storage."""
+        try:
+            with open(f"profiles/user_{self.user_id}.json", "r") as f:
+                return json.load(f)
+        except FileNotFoundError:
+            return {"user_id": self.user_id, "facts": []}
+
+    def save_profile(self):
+        """Save profile to storage."""
+        with open(f"profiles/user_{self.user_id}.json", "w") as f:
+            json.dump(self.profile, f)
+
+    def update_profile(self, new_facts):
+        """Add new facts to profile."""
+        self.profile["facts"].extend(new_facts)
+        self.profile["last_updated"] = datetime.now().isoformat()
+        self.save_profile()
+
+    def get_profile_summary(self):
+        """Get summary for LLM context."""
+        if not self.profile["facts"]:
+            return ""
+
+        return "User profile:\n" + "\n".join([
+            f"- {fact}" for fact in self.profile["facts"]
+        ])
+```
+
+The profile is a simple structure: a user ID, a list of facts, and a timestamp for the last update. The `get_profile_summary` method formats the profile as a string that can be injected directly into the system prompt.
+
+In a production system, you would also want deduplication (don't store "prefers Python" five times), conflict resolution (if the user says "I switched from Flask to Django," update the profile rather than keeping both), and expiry (some facts become stale over time). These refinements add complexity but significantly improve profile quality. A simple approach to deduplication is to periodically ask the LLM to consolidate the profile — merge duplicates, resolve contradictions, and remove outdated information.
+
+## Personalised Responses
+
+The `PersonalizedChatbot` class ties everything together. It combines the hybrid memory architecture from the previous section with the user profile system to produce responses that are tailored to the specific user:
+
+```python
+class PersonalizedChatbot:
+    def __init__(self, user_id):
+        self.user_id = user_id
+        self.profile_manager = UserProfileManager(user_id)
+        self.memory = HybridMemoryChatbot(user_id)
+
+    def chat(self, user_message):
+        """Generate personalized response."""
+
+        profile_summary = self.profile_manager.get_profile_summary()
+
+        system_prompt = f"""You are a helpful programming assistant.
+
+{profile_summary}
+
+Tailor your responses based on the user's profile:
+- Adjust technical level to their experience
+- Consider their preferences and constraints
+- Reference their goals when relevant
+- Build on previous conversations
+"""
+
+        response = self.memory.chat(user_message, system_prompt=system_prompt)
+
+        # Periodically update profile
+        if self.memory.turn_counter % 10 == 0:
+            self.update_user_profile()
+
+        return response
+
+    def update_user_profile(self):
+        """Extract new facts from recent conversation."""
+        recent_turns = self.memory.current_window[-20:]
+
+        if len(recent_turns) < 4:
+            return
+
+        new_facts = extract_user_info(recent_turns)
+
+        if new_facts:
+            self.profile_manager.update_profile([new_facts])
+```
+
+The impact of personalisation is best illustrated by comparing responses to the same question. Without personalisation, the question "Which database should I use?" produces a generic overview of popular options. With personalisation — knowing that the user is a beginner, uses Python and Flask, is building a blog, and works on Windows — the response becomes specific and actionable: "Since you're building a blog with Python and you're still learning, I'd recommend starting with SQLite. It's simple, requires no setup, and works great with Flask. Once your blog grows, you can migrate to PostgreSQL."
+
+The personalised response is more useful because it considers the user's actual situation rather than providing a one-size-fits-all answer. Over multiple sessions, the profile accumulates enough context to make every response feel like it comes from an assistant who genuinely knows the user.
+
+A note on privacy: personalisation requires storing information about users. Be transparent about what you're storing, give users the ability to view and delete their profiles, and comply with data protection regulations (GDPR, CCPA, etc.). The "right to be forgotten" is not just a legal requirement — it's good practice. If a user asks the bot to forget something, you should be able to remove it from their profile and conversation history.
+
+::::challenge{id=m4-05-ex1 title="Token Window Management"}
+
+Implement a `TokenWindowChatbot` that manages conversation history by token count. Test it with a 30-turn conversation and track how token usage changes over time.
+
+```python
+class TokenWindowChatbot:
+    def __init__(self, max_tokens=2000):
+        # TODO: Initialize with system prompt, history list, and tiktoken encoding
+        pass
+
+    def chat(self, user_message):
+        # TODO: Add the user message to history
+        # TODO: Prune oldest message pairs while over the token limit
+        # TODO: Call the API and append the assistant response
+        pass
+
+    def get_token_count(self):
+        # TODO: Return current token usage
+        pass
+
+# Test with a long conversation
+bot = TokenWindowChatbot(max_tokens=1000)
+for i in range(30):
+    bot.chat(f"Question {i+1}: Tell me about topic {i+1}.")
+    print(f"Turn {i+1}: {bot.get_token_count()} tokens")
+```
+
+Observe how the token count climbs and then stabilises once the window limit kicks in. Try different `max_tokens` values (500, 1000, 2000) and note the trade-off between context retention and token budget.
+::::
+
+::::challenge{id=m4-05-ex2 title="Conversation Summarisation"}
+
+Build a `SummarizingChatbot` and test whether summarisation preserves specific facts across a long conversation.
+
+```python
+class SummarizingChatbot:
+    def summarize_messages(self, messages):
+        # TODO: Generate a concise summary using the LLM
+        pass
+
+    def chat(self, user_message):
+        # TODO: Add message, summarise if threshold reached, generate response
+        pass
+
+# Recall test
+bot = SummarizingChatbot()
+bot.chat("My account ID is ABC123")  # Turn 1
+# ... 23 more turns about various topics ...
+response = bot.chat("What was my account ID?")  # Turn 25
+assert "ABC123" in response  # Should be preserved in the summary
+```
+
+If the account ID is lost in the summary, think about why. Summarisation is lossy by design — the LLM decides what's important enough to keep. This is exactly the problem that selective memory (covered earlier in this module) addresses. Consider how you might combine the two approaches.
+::::
+
+::::challenge{id=m4-05-ex3 title="Retrieval-Based Memory"}
+
+Implement a `ConversationalMemory` class and test cross-session recall.
+
+```python
+memory = ConversationalMemory(user_id="test_user")
+
+# Day 1
+memory.chat("I'm having trouble with Docker deployment")
+memory.chat("The error is 'permission denied'")
+# ... 10 more turns about Docker ...
+
+# Day 2 (new session, same user)
+memory2 = ConversationalMemory(user_id="test_user")
+response = memory2.chat("What was that Docker issue we discussed?")
+
+# Verify retrieval worked
+assert "Docker" in response
+assert "permission denied" in response
+```
+
+The key test is whether the second session can access information from the first. If it works, the bot has genuine long-term memory. Try varying the number of retrieved turns (`top_k`) and see how it affects both response quality and latency.
+::::
+
+::::challenge{id=m4-05-ex4 title="User Profile Extraction"}
+
+Build a user profile system and verify that it extracts facts correctly.
+
+```python
+profile_mgr = UserProfileManager(user_id="test_user")
+
+conversation = [
+    {"role": "user", "content": "I'm a data scientist using Python"},
+    {"role": "assistant", "content": "Great, Python is excellent for data science."},
+    {"role": "user", "content": "I prefer pandas over numpy for data manipulation"},
+    {"role": "assistant", "content": "Pandas is very intuitive for tabular data."},
+    {"role": "user", "content": "I work on a MacBook Pro"},
+    {"role": "assistant", "content": "macOS is a popular choice for data science."},
+]
+
+# Extract profile from conversation
+profile_text = extract_user_info(conversation)
+profile_mgr.update_profile([profile_text])
+
+profile = profile_mgr.get_profile_summary()
+
+# Verify extraction
+assert "data scientist" in profile.lower()
+assert "python" in profile.lower()
+assert "pandas" in profile.lower()
+```
+
+After verifying that extraction works, integrate the profile into a chatbot's system prompt and observe how responses change. Ask the same technical question with and without the profile to see the difference.
+::::
+
+::::challenge{id=m4-05-checkpoint title="Project Checkpoint 4: Add Memory to Your Chatbot"}
+
+Enhance your capstone project with at least two memory strategies from this module. Your chatbot should handle extended conversations gracefully, retaining important context without exceeding token limits.
+
+Your deliverables should include:
+
+- Implementation of at least two memory strategies (conversation summarisation, token management, retrieval-based memory, or user profiles)
+- Successful handling of 50+ turn conversations without exceeding the context window
+- Demonstration of memory recall across turns (referencing information from turn 10 at turn 40)
+- Evidence of token usage staying bounded over time
+- Documentation of which strategies you chose and why
+
+Test your implementation against these cases:
+
+1. **Long Conversation:** Run 50 turns without errors or context window overflow.
+2. **Recall Test:** Tell the bot something specific at turn 10, then ask about it at turn 40.
+3. **Cross-Session Memory:** End a session, start a new one, and verify the bot remembers key facts.
+4. **Personalisation:** Confirm that the bot adapts its responses based on accumulated user profile information.
+
+The choice of which strategies to combine depends on your application domain. Customer support bots benefit most from summarisation (to track the troubleshooting thread) and retrieval (to recall previous tickets). Tutoring bots prioritise user profiles (to track learning progress) and selective memory (to retain key concepts the student has mastered). Personal assistants need all four layers to provide a truly continuous experience.
+::::
+
+## Summary and What's Next
+
+In this module, you've built the memory systems that transform a stateless chatbot into a contextual, continuous assistant. You started with the fundamental challenge — unbounded conversation history exceeds context windows and budgets — and progressively developed more sophisticated solutions. Fixed and token-based windows provide a simple baseline. Rolling and hierarchical summarisation compress older history while preserving key points. Selective memory uses importance scoring to ensure critical facts survive pruning. Retrieval-based memory extends recall to any point in the user's history, across sessions. User profiles accumulate knowledge about the user and enable personalised responses. The hybrid architecture combines all four layers into a production-ready system that handles conversations of any length within a bounded token budget.
+
+In Module 5, you'll shift from building chatbot intelligence to deploying it. You'll design a FastAPI backend to serve your chatbot as an API, build frontend interfaces with Streamlit and React, containerise everything with Docker, deploy to the cloud, and implement authentication and security. The chatbot you've built across Modules 1–4 will become a production service that real users can access.
+
+## Additional Resources
+
+- ["Memory-Augmented Neural Networks"](https://arxiv.org/abs/1410.5401) (Graves et al., 2014) — Foundational work on external memory for neural networks
+- ["Memory Networks"](https://arxiv.org/abs/1410.3916) (Weston et al., 2015) — End-to-end memory architectures
+- ["Attention Is All You Need"](https://arxiv.org/abs/1706.03762) (Vaswani et al., 2017) — The transformer architecture that makes context windows possible
+- [tiktoken](https://github.com/openai/tiktoken) — OpenAI's token counting library
+- [ChromaDB](https://www.trychroma.com/) — Vector database for conversation memory storage
+
+## Hands-on practical
+
+Work through the accompanying notebook: [`module_4/05-user-personalisation.ipynb`](https://github.com/OxfordCompetencyCenters/aicc_chatbot_modules/blob/main/module_4/05-user-personalisation.ipynb). It walks through LLM-based fact extraction, a JSON-backed `UserProfile` class, and a comparison of generic vs personalised answers to the same question.

--- a/technology_and_tooling/chatbot_development/m5-01-backend-design-with-fastapi.md
+++ b/technology_and_tooling/chatbot_development/m5-01-backend-design-with-fastapi.md
@@ -1,0 +1,209 @@
+---
+name: Backend Design with FastAPI
+dependsOn:
+  - technology_and_tooling.chatbot_development.m4-05-user-personalisation
+tags: [chatbots, deployment, fastapi, api-design, optional]
+learningOutcomes:
+  - Design RESTful API endpoints for a chatbot service.
+  - Implement a FastAPI backend with Pydantic request/response models.
+  - Add real-time response streaming using Server-Sent Events.
+attribution:
+  - citation: >
+      Oxford AI Competency Centre (2026). Chatbot Development Course.
+    url: https://github.com/OxfordCompetencyCenters/aicc_chatbot_modules
+    license: CC-BY-4.0
+---
+
+Up to this point, your chatbot has lived in a Python script or Jupyter notebook. It works on your machine, but no one else can use it. To turn it into a product — something accessible over the internet, integrated into other applications, or used by multiple people simultaneously — you need to wrap it in an API. The API is the boundary between your chatbot's intelligence and the outside world. Clients (web apps, mobile apps, other services) send HTTP requests to your API, and the API returns the chatbot's responses.
+
+FastAPI has become the standard framework for building Python APIs in the machine learning space, and for good reason. It is fast — its performance is comparable to Node.js and Go frameworks, thanks to its async foundation on Starlette and uvicorn. It provides automatic request validation through Pydantic models, so malformed requests are rejected before they reach your chatbot logic. It generates interactive API documentation (Swagger UI) at `/docs` with no additional work. And it supports async natively, which is critical for chatbots: you don't want one slow LLM call to block every other user's request.
+
+Other Python frameworks are viable alternatives. Flask is simpler and more mature but lacks built-in validation and async support. Django is full-featured but heavyweight for a pure API service. For chatbot backends specifically, FastAPI hits the sweet spot of simplicity, performance, and features.
+
+## Designing Chatbot REST Endpoints
+
+A well-designed chatbot API follows RESTful conventions. The core endpoints are:
+
+```
+POST   /chat              # Send a message, get a response
+GET    /conversations     # List a user's conversations
+GET    /conversations/:id # Get a specific conversation
+DELETE /conversations/:id # Delete a conversation
+POST   /conversations     # Start a new conversation
+GET    /health            # Health check for monitoring
+```
+
+The `/chat` endpoint is the heart of the service. It accepts a message, an optional conversation ID (to continue an existing conversation), and a user ID. It returns the chatbot's response along with metadata: the conversation ID, any source documents used (if the chatbot uses RAG), and the number of tokens consumed.
+
+```python
+# POST /chat
+# Request:
+{
+  "message": "How do I deploy my app?",
+  "conversation_id": "conv_123",
+  "user_id": "user_456"
+}
+
+# Response:
+{
+  "response": "To deploy your app, you can...",
+  "conversation_id": "conv_123",
+  "sources": ["doc1.pdf", "doc2.pdf"],
+  "tokens_used": 450
+}
+```
+
+Returning `sources` gives users transparency into where the chatbot's answer came from — this is especially important for RAG-powered chatbots where trust and verifiability matter. Returning `tokens_used` enables cost tracking on the client side, which is useful for billing or usage dashboards.
+
+The `/health` endpoint is simple but essential. Load balancers, container orchestrators (like Kubernetes), and monitoring systems use it to determine whether your service is running and ready to accept traffic. If the health check fails, the platform can automatically restart the container or route traffic elsewhere.
+
+Good REST API design also means using HTTP methods correctly (GET for reading, POST for creating, DELETE for removing), returning appropriate status codes (200 for success, 201 for creation, 400 for bad requests, 401 for authentication failures, 500 for server errors), and versioning your API (`/v1/chat`) so you can evolve the interface without breaking existing clients.
+
+## Building the FastAPI Backend
+
+Here is a complete implementation that wraps the hybrid memory chatbot from Module 4 in a FastAPI service:
+
+```python
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel
+from typing import Optional, List
+import uvicorn
+import time
+
+app = FastAPI(
+    title="Chatbot API",
+    description="Production chatbot with RAG and memory",
+    version="1.0.0"
+)
+
+class ChatRequest(BaseModel):
+    message: str
+    conversation_id: Optional[str] = None
+    user_id: str
+
+class ChatResponse(BaseModel):
+    response: str
+    conversation_id: str
+    sources: List[str] = []
+    tokens_used: int
+
+from your_chatbot import HybridMemoryChatbot
+
+chatbot_instances = {}
+
+@app.post("/chat", response_model=ChatResponse)
+async def chat(request: ChatRequest):
+    """Send a message to the chatbot and get a response."""
+    try:
+        conv_id = request.conversation_id or f"conv_{request.user_id}_{int(time.time())}"
+
+        if conv_id not in chatbot_instances:
+            chatbot_instances[conv_id] = HybridMemoryChatbot(user_id=request.user_id)
+
+        chatbot = chatbot_instances[conv_id]
+        result = chatbot.chat(request.message)
+
+        return ChatResponse(
+            response=result["answer"],
+            conversation_id=conv_id,
+            sources=result.get("sources", []),
+            tokens_used=result.get("tokens_used", 0)
+        )
+
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+
+@app.get("/conversations")
+async def list_conversations(user_id: str):
+    """List all conversations for a user."""
+    user_convs = [
+        conv_id for conv_id in chatbot_instances
+        if conv_id.startswith(f"conv_{user_id}_")
+    ]
+    return {"conversations": user_convs}
+
+@app.delete("/conversations/{conversation_id}")
+async def delete_conversation(conversation_id: str):
+    """Delete a conversation."""
+    if conversation_id in chatbot_instances:
+        del chatbot_instances[conversation_id]
+        return {"status": "deleted"}
+    raise HTTPException(status_code=404, detail="Conversation not found")
+
+@app.get("/health")
+async def health_check():
+    """Health check endpoint."""
+    return {"status": "healthy", "version": "1.0.0"}
+
+if __name__ == "__main__":
+    uvicorn.run(app, host="0.0.0.0", port=8000)
+```
+
+The Pydantic models (`ChatRequest` and `ChatResponse`) serve double duty: they validate incoming requests automatically (rejecting any request that doesn't match the schema) and they generate the API documentation. When you run this server and visit `http://localhost:8000/docs`, you get an interactive Swagger UI where you can test every endpoint directly from the browser.
+
+The `chatbot_instances` dictionary stores active chatbot instances in memory, keyed by conversation ID. This is sufficient for development and single-server deployments. In a production environment with multiple server instances, you would store conversation state in a shared database (PostgreSQL, Redis, or similar) so that any server can handle any request.
+
+To run the server:
+
+```bash
+pip install fastapi uvicorn[standard]
+python main.py
+```
+
+The API is then available at `http://localhost:8000`, with interactive documentation at `http://localhost:8000/docs`.
+
+## Streaming Responses
+
+LLM responses can take 5–10 seconds or more for long outputs. Without streaming, the user stares at a blank screen for the entire duration and then sees the complete response appear all at once. With streaming, tokens appear as they are generated — the same experience as ChatGPT. The perceived performance improvement is dramatic, even though the total time to generate the response is the same.
+
+The standard approach for streaming in HTTP APIs is Server-Sent Events (SSE). SSE is simpler than WebSockets for this use case because the communication is one-directional: the server streams data to the client. The client opens a connection, and the server sends events as they become available.
+
+```python
+from fastapi.responses import StreamingResponse
+import json
+
+@app.post("/chat/stream")
+async def chat_stream(request: ChatRequest):
+    """Stream chatbot response token by token."""
+
+    async def generate():
+        conv_id = request.conversation_id or f"conv_{request.user_id}_{int(time.time())}"
+        chatbot = chatbot_instances.get(conv_id) or HybridMemoryChatbot(request.user_id)
+        chatbot_instances[conv_id] = chatbot
+
+        # OpenAI streaming
+        response = openai.ChatCompletion.create(
+            model="gpt-3.5-turbo",
+            messages=chatbot.build_messages(request.message),
+            stream=True
+        )
+
+        for chunk in response:
+            if chunk.choices[0].delta.get("content"):
+                token = chunk.choices[0].delta.content
+                yield f"data: {json.dumps({'token': token})}\n\n"
+
+        yield f"data: {json.dumps({'done': True, 'conversation_id': conv_id})}\n\n"
+
+    return StreamingResponse(generate(), media_type="text/event-stream")
+```
+
+The OpenAI API supports streaming natively through the `stream=True` parameter. Instead of returning the complete response, it yields chunks as they are generated. Each chunk contains a small piece of the response (typically one or a few tokens). The FastAPI `StreamingResponse` wraps the generator function and sends each yielded string to the client as an SSE event.
+
+On the client side, JavaScript's `EventSource` API handles SSE connections:
+
+```javascript
+const eventSource = new EventSource('/chat/stream');
+
+eventSource.onmessage = (event) => {
+  const data = JSON.parse(event.data);
+
+  if (data.done) {
+    eventSource.close();
+  } else {
+    chatDisplay.textContent += data.token;
+  }
+};
+```
+
+Each token arrives as a separate event. The client appends it to the display, creating the characteristic "typing" effect. When the server sends the `done` signal, the client closes the connection. This pattern works well for chatbot interfaces because users can start reading the response immediately, which makes even slow LLM calls feel responsive.

--- a/technology_and_tooling/chatbot_development/m5-01-backend-design-with-fastapi.md
+++ b/technology_and_tooling/chatbot_development/m5-01-backend-design-with-fastapi.md
@@ -11,6 +11,7 @@ attribution:
   - citation: >
       Oxford AI Competency Centre (2026). Chatbot Development Course.
     url: https://github.com/OxfordCompetencyCenters/aicc_chatbot_modules
+    image: https://github.com/OxfordCompetencyCenters.png
     license: CC-BY-4.0
 ---
 

--- a/technology_and_tooling/chatbot_development/m5-02-frontend-integration.md
+++ b/technology_and_tooling/chatbot_development/m5-02-frontend-integration.md
@@ -1,0 +1,265 @@
+---
+name: Frontend Integration
+dependsOn:
+  - technology_and_tooling.chatbot_development.m5-01-backend-design-with-fastapi
+tags: [chatbots, deployment, streamlit, react, frontend, optional]
+learningOutcomes:
+  - Build a rapid-prototype chatbot UI with Streamlit.
+  - Create a production-grade chat interface with React.
+  - Connect frontend applications to a FastAPI backend.
+attribution:
+  - citation: >
+      Oxford AI Competency Centre (2026). Chatbot Development Course.
+    url: https://github.com/OxfordCompetencyCenters/aicc_chatbot_modules
+    license: CC-BY-4.0
+---
+
+An API is useful for programmatic access and integration with other services, but most end users interact with chatbots through a visual interface. The choice of frontend technology depends on your audience and timeline. For internal tools, demos, and rapid prototyping, Streamlit lets you build a functional chat UI in pure Python with no web development knowledge. For production-facing applications where you need full control over the user experience, React (or a similar JavaScript framework) is the standard choice.
+
+## Streamlit for Rapid Prototyping
+
+Streamlit is a Python library that turns scripts into interactive web applications. You write Python, and Streamlit handles the HTML, CSS, and JavaScript. For chatbot interfaces, Streamlit provides dedicated components — `st.chat_message` for rendering message bubbles and `st.chat_input` for the text input field — that create a ChatGPT-like experience with minimal code.
+
+The typical use cases for a Streamlit chatbot frontend are internal tools, demos for stakeholders, MVPs, and non-public applications. Anywhere that speed of development matters more than pixel-perfect design, Streamlit is the right choice.
+
+Here is a complete Streamlit chatbot interface that communicates with the FastAPI backend:
+
+```python
+import streamlit as st
+import requests
+
+st.title("AI Chatbot")
+
+# Initialize chat history in session state
+if "messages" not in st.session_state:
+    st.session_state.messages = []
+
+# Display chat history
+for message in st.session_state.messages:
+    with st.chat_message(message["role"]):
+        st.markdown(message["content"])
+
+# Chat input
+if prompt := st.chat_input("Ask me anything..."):
+    st.session_state.messages.append({"role": "user", "content": prompt})
+
+    with st.chat_message("user"):
+        st.markdown(prompt)
+
+    with st.chat_message("assistant"):
+        message_placeholder = st.empty()
+
+        response = requests.post(
+            "http://localhost:8000/chat",
+            json={
+                "message": prompt,
+                "user_id": "streamlit_user",
+                "conversation_id": st.session_state.get("conv_id")
+            }
+        )
+
+        if response.status_code == 200:
+            data = response.json()
+            full_response = data["response"]
+            st.session_state["conv_id"] = data["conversation_id"]
+
+            message_placeholder.markdown(full_response)
+
+            if data.get("sources"):
+                with st.expander("Sources"):
+                    for source in data["sources"]:
+                        st.write(f"- {source}")
+        else:
+            st.error("Error calling chatbot API")
+
+    st.session_state.messages.append({"role": "assistant", "content": full_response})
+
+# Sidebar controls
+with st.sidebar:
+    st.header("Controls")
+
+    if st.button("Clear Conversation"):
+        st.session_state.messages = []
+        st.session_state.pop("conv_id", None)
+        st.rerun()
+
+    st.divider()
+    st.caption("Powered by OpenAI GPT-3.5")
+```
+
+This is roughly 50 lines of Python, and it produces a fully functional chat interface. `st.session_state` persists data across Streamlit's reruns (Streamlit re-executes the entire script on every interaction). The chat history is stored in session state and re-rendered on each run. The sidebar provides controls like clearing the conversation. The sources expander shows RAG attribution when available.
+
+To run it:
+
+```bash
+pip install streamlit
+streamlit run app.py
+```
+
+Streamlit opens the application in your browser automatically. The interface auto-reloads when you change the code, making the development cycle fast.
+
+## React for Production Interfaces
+
+For user-facing applications that need full control over the experience — custom styling, complex interactions, offline support, accessibility — React is the standard. A React frontend communicates with the same FastAPI backend through HTTP requests, but gives you complete control over how the interface looks and behaves.
+
+Here is a React chat component:
+
+```javascript
+import React, { useState, useEffect, useRef } from 'react';
+import './ChatInterface.css';
+
+function ChatInterface() {
+  const [messages, setMessages] = useState([]);
+  const [input, setInput] = useState('');
+  const [conversationId, setConversationId] = useState(null);
+  const [loading, setLoading] = useState(false);
+  const messagesEndRef = useRef(null);
+
+  useEffect(() => {
+    messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
+  }, [messages]);
+
+  const sendMessage = async () => {
+    if (!input.trim()) return;
+
+    const userMessage = { role: 'user', content: input };
+    setMessages(prev => [...prev, userMessage]);
+    setInput('');
+    setLoading(true);
+
+    try {
+      const response = await fetch('http://localhost:8000/chat', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          message: input,
+          user_id: 'react_user',
+          conversation_id: conversationId
+        })
+      });
+
+      const data = await response.json();
+
+      setMessages(prev => [...prev, {
+        role: 'assistant',
+        content: data.response,
+        sources: data.sources
+      }]);
+
+      setConversationId(data.conversation_id);
+    } catch (error) {
+      console.error('Error:', error);
+      setMessages(prev => [...prev, {
+        role: 'assistant',
+        content: 'Sorry, something went wrong.'
+      }]);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="chat-container">
+      <div className="messages">
+        {messages.map((msg, idx) => (
+          <div key={idx} className={`message ${msg.role}`}>
+            <div className="message-content">{msg.content}</div>
+            {msg.sources && msg.sources.length > 0 && (
+              <div className="sources">
+                Sources: {msg.sources.join(', ')}
+              </div>
+            )}
+          </div>
+        ))}
+        {loading && <div className="loading">Thinking...</div>}
+        <div ref={messagesEndRef} />
+      </div>
+
+      <div className="input-area">
+        <input
+          type="text"
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          onKeyPress={(e) => e.key === 'Enter' && sendMessage()}
+          placeholder="Type your message..."
+        />
+        <button onClick={sendMessage} disabled={loading}>
+          Send
+        </button>
+      </div>
+    </div>
+  );
+}
+
+export default ChatInterface;
+```
+
+The component manages its state with React hooks: `useState` for messages, input text, conversation ID, and loading state; `useEffect` for auto-scrolling to the bottom when new messages arrive; and `useRef` for the scroll target element. The `sendMessage` function handles the full lifecycle of a user message: adding it to the display, calling the backend API, and appending the response.
+
+The accompanying CSS provides a clean chat layout:
+
+```css
+.chat-container {
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+  max-width: 800px;
+  margin: 0 auto;
+}
+
+.messages {
+  flex: 1;
+  overflow-y: auto;
+  padding: 20px;
+}
+
+.message {
+  margin-bottom: 15px;
+  padding: 12px;
+  border-radius: 8px;
+}
+
+.message.user {
+  background: #007bff;
+  color: white;
+  margin-left: 20%;
+}
+
+.message.assistant {
+  background: #f1f1f1;
+  margin-right: 20%;
+}
+
+.sources {
+  font-size: 0.85em;
+  margin-top: 8px;
+  opacity: 0.8;
+}
+
+.input-area {
+  display: flex;
+  padding: 20px;
+  border-top: 1px solid #ddd;
+}
+
+.input-area input {
+  flex: 1;
+  padding: 12px;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+}
+
+.input-area button {
+  margin-left: 10px;
+  padding: 12px 24px;
+  background: #007bff;
+  color: white;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+}
+```
+
+This is a starting point. A production chat interface would add features like typing indicators, message timestamps, file upload support, markdown rendering in responses, keyboard shortcuts, and accessibility attributes. Libraries like `react-chat-elements` or `stream-chat-react` provide pre-built components for these features.
+
+The key architectural point is that both frontends — Streamlit and React — communicate with the same FastAPI backend through the same HTTP endpoints. The backend doesn't know or care which frontend is calling it. This separation of concerns means you can develop and deploy the frontend and backend independently, swap one frontend for another without changing the backend, and support multiple clients (web, mobile, API integrations) simultaneously.

--- a/technology_and_tooling/chatbot_development/m5-02-frontend-integration.md
+++ b/technology_and_tooling/chatbot_development/m5-02-frontend-integration.md
@@ -11,6 +11,7 @@ attribution:
   - citation: >
       Oxford AI Competency Centre (2026). Chatbot Development Course.
     url: https://github.com/OxfordCompetencyCenters/aicc_chatbot_modules
+    image: https://github.com/OxfordCompetencyCenters.png
     license: CC-BY-4.0
 ---
 

--- a/technology_and_tooling/chatbot_development/m5-03-docker-containerisation.md
+++ b/technology_and_tooling/chatbot_development/m5-03-docker-containerisation.md
@@ -11,6 +11,7 @@ attribution:
   - citation: >
       Oxford AI Competency Centre (2026). Chatbot Development Course.
     url: https://github.com/OxfordCompetencyCenters/aicc_chatbot_modules
+    image: https://github.com/OxfordCompetencyCenters.png
     license: CC-BY-4.0
 ---
 

--- a/technology_and_tooling/chatbot_development/m5-03-docker-containerisation.md
+++ b/technology_and_tooling/chatbot_development/m5-03-docker-containerisation.md
@@ -1,7 +1,7 @@
 ---
 name: Docker Containerisation
 dependsOn:
-  - technology_and_tooling.chatbot_development.m5-02-frontend-integration
+  - technology_and_tooling.chatbot_development.m5-01-backend-design-with-fastapi
 tags: [chatbots, deployment, docker, containerisation, optional]
 learningOutcomes:
   - Write a production-quality Dockerfile for a Python chatbot API.

--- a/technology_and_tooling/chatbot_development/m5-03-docker-containerisation.md
+++ b/technology_and_tooling/chatbot_development/m5-03-docker-containerisation.md
@@ -1,0 +1,253 @@
+---
+name: Docker Containerisation
+dependsOn:
+  - technology_and_tooling.chatbot_development.m5-02-frontend-integration
+tags: [chatbots, deployment, docker, containerisation, optional]
+learningOutcomes:
+  - Write a production-quality Dockerfile for a Python chatbot API.
+  - Use multi-stage builds to reduce Docker image size.
+  - Define multi-container development environments with Docker Compose.
+attribution:
+  - citation: >
+      Oxford AI Competency Centre (2026). Chatbot Development Course.
+    url: https://github.com/OxfordCompetencyCenters/aicc_chatbot_modules
+    license: CC-BY-4.0
+---
+
+Your chatbot runs on your machine. It requires a specific Python version, a set of pip packages at particular versions, system libraries for certain dependencies, and environment variables for API keys. If a colleague tries to run it, they'll spend an hour debugging installation issues. If you deploy it to a server, the server's Python version might be different, or a system library might be missing. Docker solves this by packaging your application with everything it needs into a single, portable unit called a container.
+
+A Docker **image** is a blueprint — it defines what goes into the container (operating system, Python, dependencies, your code). A **container** is a running instance of an image. A **Dockerfile** is the set of instructions that builds an image. **Docker Compose** defines multi-container applications (for example, your API plus a database plus a cache) so you can start the entire stack with one command.
+
+The workflow is: write a Dockerfile, build it into an image, run the image as a container, and deploy that container to the cloud. The same container that runs on your laptop runs identically in production.
+
+## Writing a Production Dockerfile
+
+Here is a production-quality Dockerfile for the chatbot API:
+
+```dockerfile
+# Use official Python runtime as base
+FROM python:3.10-slim
+
+# Set working directory
+WORKDIR /app
+
+# Set environment variables
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1
+
+# Install system dependencies
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    curl \
+    && rm -rf /var/lib/apt/lists/*
+
+# Copy requirements first (for layer caching)
+COPY requirements.txt .
+
+# Install Python dependencies
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy application code
+COPY . .
+
+# Create non-root user for security
+RUN useradd -m -u 1000 appuser && \
+    chown -R appuser:appuser /app
+USER appuser
+
+# Expose port
+EXPOSE 8000
+
+# Health check
+HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
+    CMD curl -f http://localhost:8000/health || exit 1
+
+# Run the application
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]
+```
+
+Several production practices are at work here. The `requirements.txt` is copied and installed before the rest of the application code. Docker caches each instruction as a layer, so if your code changes but your dependencies don't, Docker reuses the cached dependency layer — this speeds up rebuilds dramatically. The `PYTHONUNBUFFERED=1` setting ensures Python output appears in the container logs immediately rather than being buffered. Running as a non-root user (`appuser`) is a security best practice: if the application is compromised, the attacker has limited permissions. The `HEALTHCHECK` instruction tells Docker how to determine whether the container is healthy, which container orchestrators use for automatic restarts and traffic routing.
+
+The corresponding `requirements.txt` lists your dependencies with pinned versions:
+
+```
+fastapi==0.104.1
+uvicorn[standard]==0.24.0
+pydantic==2.5.0
+openai==1.3.0
+chromadb==0.4.15
+tiktoken==0.5.1
+python-dotenv==1.0.0
+```
+
+A `.dockerignore` file prevents unnecessary files from being copied into the image:
+
+```
+__pycache__
+*.pyc
+*.pyo
+*.pyd
+.Python
+env/
+venv/
+.git
+.gitignore
+.DS_Store
+.env
+*.log
+chroma_db/
+```
+
+This is important both for image size and for security — you don't want your `.env` file with API keys ending up inside the Docker image.
+
+To build and run:
+
+```bash
+# Build image
+docker build -t chatbot-api:v1 .
+
+# Run container
+docker run -d \
+  -p 8000:8000 \
+  -e OPENAI_API_KEY=sk-... \
+  --name chatbot \
+  chatbot-api:v1
+
+# Check logs
+docker logs chatbot
+
+# Stop container
+docker stop chatbot
+```
+
+The `-p 8000:8000` flag maps port 8000 inside the container to port 8000 on the host. The `-e` flag passes environment variables — this is how you provide API keys without hardcoding them in the image. The resulting image is typically around 500–650 MB, which includes the Python runtime, all dependencies, and your application code.
+
+## Multi-Stage Builds
+
+A 650 MB image works but is larger than necessary. Much of the size comes from build tools (compilers, headers) that are needed to install dependencies but aren't needed to run the application. Multi-stage builds solve this by separating the build environment from the runtime environment:
+
+```dockerfile
+# Stage 1: Builder
+FROM python:3.10 as builder
+
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --user --no-cache-dir -r requirements.txt
+
+# Stage 2: Runtime
+FROM python:3.10-slim
+
+WORKDIR /app
+
+# Copy only installed packages from builder
+COPY --from=builder /root/.local /root/.local
+
+# Copy application code
+COPY . .
+
+ENV PATH=/root/.local/bin:$PATH
+
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]
+```
+
+The first stage uses the full Python image (which includes build tools) to compile and install all dependencies. The second stage starts from the slim image (which has only the Python runtime) and copies over the installed packages. The build tools are left behind in the first stage, never appearing in the final image.
+
+The size difference is substantial:
+
+```
+Single-stage build:  ~650 MB
+Multi-stage build:   ~180 MB
+```
+
+Smaller images mean faster pulls from the container registry, faster scaling (when new containers need to start), and lower storage costs. At scale — hundreds of containers across multiple environments — this adds up.
+
+For even smaller images, you can use Alpine Linux as the base (`python:3.10-alpine`), though this can introduce compatibility issues with some Python packages that expect a glibc-based system. For most chatbot applications, the slim variant strikes the right balance between size and compatibility.
+
+## Docker Compose for Local Development
+
+A production chatbot system typically involves more than just the API server. You'll have a database for storing conversations and user profiles, a cache for session management, and potentially a frontend application. Docker Compose lets you define all of these services in a single YAML file and start them together:
+
+```yaml
+version: '3.8'
+
+services:
+  # FastAPI backend
+  api:
+    build: ./backend
+    ports:
+      - "8000:8000"
+    environment:
+      - OPENAI_API_KEY=${OPENAI_API_KEY}
+      - DATABASE_URL=postgresql://user:pass@db:5432/chatbot
+      - REDIS_URL=redis://redis:6379
+    depends_on:
+      - db
+      - redis
+    volumes:
+      - ./backend:/app
+    command: uvicorn main:app --host 0.0.0.0 --reload
+
+  # PostgreSQL database
+  db:
+    image: postgres:15-alpine
+    environment:
+      - POSTGRES_USER=user
+      - POSTGRES_PASSWORD=pass
+      - POSTGRES_DB=chatbot
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    ports:
+      - "5432:5432"
+
+  # Redis for caching and sessions
+  redis:
+    image: redis:7-alpine
+    ports:
+      - "6379:6379"
+    volumes:
+      - redis_data:/data
+
+  # React frontend
+  frontend:
+    build: ./frontend
+    ports:
+      - "3000:3000"
+    environment:
+      - REACT_APP_API_URL=http://localhost:8000
+    volumes:
+      - ./frontend:/app
+      - /app/node_modules
+    command: npm start
+
+volumes:
+  postgres_data:
+  redis_data:
+```
+
+This configuration defines four services. The `api` service builds from the `./backend` directory and connects to both the database and Redis. The `db` service runs PostgreSQL with a persistent volume so data survives container restarts. The `redis` service provides a cache layer. The `frontend` service runs the React development server.
+
+Services can reference each other by name — the API connects to the database at `postgresql://user:pass@db:5432/chatbot` where `db` is the service name, not a hostname. Docker Compose handles the networking automatically. The `depends_on` directive ensures the database and cache start before the API.
+
+The `volumes` entries serve two purposes. Named volumes (`postgres_data`, `redis_data`) persist data across container restarts. Bind mounts (`./backend:/app`) map your local source code into the container, so code changes are reflected immediately without rebuilding the image. The `--reload` flag on the uvicorn command enables auto-restart on file changes, giving you a fast development loop.
+
+To manage the stack:
+
+```bash
+# Start all services
+docker-compose up
+
+# Start in background
+docker-compose up -d
+
+# View logs for a specific service
+docker-compose logs -f api
+
+# Stop all services
+docker-compose down
+
+# Rebuild after dependency changes
+docker-compose up --build
+```
+
+With Docker Compose, every developer on the team gets an identical environment with a single command. There's no need to install PostgreSQL locally, configure Redis, or worry about version mismatches. The development environment matches production as closely as possible, reducing the "works on my machine" class of bugs.

--- a/technology_and_tooling/chatbot_development/m5-04-cloud-deployment.md
+++ b/technology_and_tooling/chatbot_development/m5-04-cloud-deployment.md
@@ -1,0 +1,105 @@
+---
+name: Cloud Deployment
+dependsOn:
+  - technology_and_tooling.chatbot_development.m5-03-docker-containerisation
+tags: [chatbots, deployment, cloud, google-cloud-run, optional]
+learningOutcomes:
+  - Compare deployment platforms and choose the right one for your use case.
+  - Deploy a containerised chatbot API to Google Cloud Run.
+  - Configure cloud resources including memory, CPU, and scaling limits.
+attribution:
+  - citation: >
+      Oxford AI Competency Centre (2026). Chatbot Development Course.
+    url: https://github.com/OxfordCompetencyCenters/aicc_chatbot_modules
+    license: CC-BY-4.0
+---
+
+Your chatbot is containerised and runs locally. The next step is making it accessible to users on the internet. Cloud deployment options range from simple push-to-deploy platforms to fully managed container services to complex but powerful Kubernetes clusters. The right choice depends on your traffic volume, budget, operational expertise, and scaling requirements.
+
+## Choosing a Deployment Platform
+
+There are four broad categories of deployment platforms, each with distinct trade-offs.
+
+**Serverless functions** (AWS Lambda, Google Cloud Functions) execute your code in response to individual requests. They scale automatically from zero to thousands of concurrent invocations and charge only for compute time used. However, they suffer from cold starts — the first request after a period of inactivity can be slow as the runtime initialises. They also impose execution time limits (typically 15 minutes maximum) and are awkward for stateful applications. For chatbots, cold starts are particularly problematic because they add noticeable latency to the first message in a conversation, and LLM calls can approach the time limit for complex queries.
+
+**Container services** (AWS ECS, Google Cloud Run, Azure Container Instances) run your Docker containers in a managed environment. They handle provisioning, scaling, and networking while giving you control over the container itself. They support long-running processes, handle state more naturally than serverless functions, and scale based on traffic. For most production chatbots, container services are the sweet spot — they provide enough control for custom configurations without the operational burden of managing servers.
+
+**Kubernetes** (AWS EKS, Google GKE, Azure AKS) provides maximum control and flexibility. It handles container orchestration, service discovery, load balancing, rolling updates, and self-healing. It's portable across cloud providers and supports complex multi-service architectures. The downside is complexity: Kubernetes requires significant DevOps expertise to configure and maintain, and it's overkill for small-to-medium projects. Reserve Kubernetes for large-scale applications with multiple services that need fine-grained control over networking, scaling policies, and deployment strategies.
+
+**Platform-as-a-Service** (Render, Railway, Heroku) offers the simplest deployment experience. You connect your Git repository, and the platform handles building, deploying, and scaling. Many offer free tiers for development and hobby projects. The trade-off is less control and higher costs at scale. These platforms are excellent for MVPs, prototypes, and small applications where time-to-deploy matters more than cost optimisation.
+
+The practical recommendation is to start with a PaaS (Render or Railway) or Cloud Run for initial deployment. Graduate to ECS or Kubernetes as your traffic and complexity grow.
+
+## Deploying to Google Cloud Run
+
+Google Cloud Run is a fully managed container service that runs Docker containers without requiring you to manage servers. It scales automatically based on traffic — including scaling to zero when idle, so you pay nothing during quiet periods. It provides HTTPS endpoints automatically and integrates with Google Cloud's ecosystem for databases, secret management, and monitoring.
+
+The deployment process has four steps: install the Google Cloud SDK, build and push your Docker image, deploy to Cloud Run, and verify the deployment.
+
+**Step 1: Install and configure the Google Cloud SDK.**
+
+```bash
+curl https://sdk.cloud.google.com | bash
+gcloud auth login
+gcloud config set project your-project-id
+```
+
+**Step 2: Build and push your Docker image to Google Container Registry.**
+
+```bash
+# Enable required APIs
+gcloud services enable run.googleapis.com
+gcloud services enable containerregistry.googleapis.com
+
+# Build and push using Google Cloud Build
+gcloud builds submit --tag gcr.io/your-project-id/chatbot-api
+```
+
+This command sends your source code to Google Cloud Build, which builds the Docker image remotely and pushes it to the container registry. Alternatively, you can build locally and push:
+
+```bash
+docker build -t gcr.io/your-project-id/chatbot-api .
+docker push gcr.io/your-project-id/chatbot-api
+```
+
+**Step 3: Deploy the image to Cloud Run.**
+
+```bash
+gcloud run deploy chatbot-api \
+  --image gcr.io/your-project-id/chatbot-api \
+  --platform managed \
+  --region us-central1 \
+  --allow-unauthenticated \
+  --set-env-vars OPENAI_API_KEY=sk-... \
+  --memory 2Gi \
+  --cpu 2 \
+  --max-instances 10 \
+  --timeout 60s
+```
+
+The flags configure the deployment: `--memory 2Gi` and `--cpu 2` allocate resources for each container instance (LLM-backed chatbots need more memory than typical web services). `--max-instances 10` caps the number of concurrent containers to control costs. `--timeout 60s` sets the maximum request duration. `--allow-unauthenticated` makes the endpoint publicly accessible (remove this flag if you're handling authentication in your API).
+
+**Step 4: Retrieve the deployment URL.**
+
+```bash
+gcloud run services describe chatbot-api \
+  --platform managed \
+  --region us-central1 \
+  --format 'value(status.url)'
+```
+
+This outputs a URL like `https://chatbot-api-abc123-uc.a.run.app`. Your chatbot API is now live on the internet.
+
+To update after code changes, rebuild the image and redeploy:
+
+```bash
+gcloud builds submit --tag gcr.io/your-project-id/chatbot-api
+gcloud run deploy chatbot-api \
+  --image gcr.io/your-project-id/chatbot-api \
+  --platform managed \
+  --region us-central1
+```
+
+For production use, you would add several refinements: a custom domain instead of the auto-generated URL, Google Secret Manager for API keys instead of passing them as environment variables, a Cloud SQL database for persistent storage, Cloud Monitoring for alerts and dashboards, and a CI/CD pipeline (using Cloud Build or GitHub Actions) to automate the build-and-deploy process on every push to main.
+
+Cost-wise, Cloud Run is economical for moderate traffic. Handling 100,000 requests per month with the configuration above might cost $5–10 in compute (not counting the LLM API costs, which are typically the dominant expense for chatbot applications). The scale-to-zero feature means you pay nothing during periods of inactivity, which makes it particularly cost-effective for internal tools and low-traffic applications.

--- a/technology_and_tooling/chatbot_development/m5-04-cloud-deployment.md
+++ b/technology_and_tooling/chatbot_development/m5-04-cloud-deployment.md
@@ -1,7 +1,7 @@
 ---
 name: Cloud Deployment
 dependsOn:
-  - technology_and_tooling.chatbot_development.m5-03-docker-containerisation
+  - technology_and_tooling.chatbot_development.m5-01-backend-design-with-fastapi
 tags: [chatbots, deployment, cloud, google-cloud-run, optional]
 learningOutcomes:
   - Compare deployment platforms and choose the right one for your use case.

--- a/technology_and_tooling/chatbot_development/m5-04-cloud-deployment.md
+++ b/technology_and_tooling/chatbot_development/m5-04-cloud-deployment.md
@@ -11,6 +11,7 @@ attribution:
   - citation: >
       Oxford AI Competency Centre (2026). Chatbot Development Course.
     url: https://github.com/OxfordCompetencyCenters/aicc_chatbot_modules
+    image: https://github.com/OxfordCompetencyCenters.png
     license: CC-BY-4.0
 ---
 

--- a/technology_and_tooling/chatbot_development/m5-05-authentication-and-security.md
+++ b/technology_and_tooling/chatbot_development/m5-05-authentication-and-security.md
@@ -1,7 +1,7 @@
 ---
 name: Authentication and Security
 dependsOn:
-  - technology_and_tooling.chatbot_development.m5-04-cloud-deployment
+  - technology_and_tooling.chatbot_development.m5-01-backend-design-with-fastapi
 tags: [chatbots, deployment, authentication, jwt, security, optional]
 learningOutcomes:
   - Implement JWT-based authentication for a FastAPI chatbot backend.

--- a/technology_and_tooling/chatbot_development/m5-05-authentication-and-security.md
+++ b/technology_and_tooling/chatbot_development/m5-05-authentication-and-security.md
@@ -1,0 +1,282 @@
+---
+name: Authentication and Security
+dependsOn:
+  - technology_and_tooling.chatbot_development.m5-04-cloud-deployment
+tags: [chatbots, deployment, authentication, jwt, security, optional]
+learningOutcomes:
+  - Implement JWT-based authentication for a FastAPI chatbot backend.
+  - Manage secrets and environment variables securely across environments.
+  - Apply security best practices for production chatbot deployments.
+attribution:
+  - citation: >
+      Oxford AI Competency Centre (2026). Chatbot Development Course.
+    url: https://github.com/OxfordCompetencyCenters/aicc_chatbot_modules
+    license: CC-BY-4.0
+---
+
+A publicly deployed chatbot API without authentication is an open invitation for abuse. Anyone who discovers the URL can send unlimited requests, consuming your LLM API credits and potentially accessing other users' conversation data. Authentication verifies that each request comes from a legitimate user, and authorisation ensures they can only access their own data.
+
+## JWT Authentication
+
+JSON Web Tokens (JWT) are the standard approach for stateless API authentication. A JWT is a signed token that contains encoded claims — typically a user identifier and an expiration timestamp. The server issues a token when the user logs in, and the client includes that token in the `Authorization` header of every subsequent request. The server validates the token's signature and expiration without needing to look up a session in a database, which makes JWT inherently scalable.
+
+A JWT consists of three parts separated by dots: a header (specifying the algorithm), a payload (containing claims like user ID and expiration), and a signature (proving the token hasn't been tampered with). The token looks like this:
+
+```
+eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.
+eyJ1c2VyX2lkIjoiMTIzIiwiZXhwIjoxNjk5OTk5OTk5fQ.
+SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c
+```
+
+The authentication flow works as follows. The user sends their credentials (username and password) to a login endpoint. The server validates the credentials, creates a JWT containing the user's identity and an expiration time, and returns it. The client stores the token and includes it as a `Bearer` token in the `Authorization` header of all subsequent requests. The server extracts the token from the header, verifies its signature and expiration, and either processes the request or returns a 401 Unauthorized error.
+
+Here is a complete implementation in FastAPI:
+
+```python
+from fastapi import FastAPI, Depends, HTTPException, status
+from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
+from pydantic import BaseModel
+from datetime import datetime, timedelta
+import jwt
+import bcrypt
+import os
+
+app = FastAPI()
+
+SECRET_KEY = os.getenv("SECRET_KEY", "change-this-in-production")
+ALGORITHM = "HS256"
+ACCESS_TOKEN_EXPIRE_MINUTES = 60
+
+security = HTTPBearer()
+
+class User(BaseModel):
+    username: str
+    password: str
+
+class Token(BaseModel):
+    access_token: str
+    token_type: str
+
+# In production, use a real database
+fake_users_db = {
+    "demo": {
+        "username": "demo",
+        "password_hash": bcrypt.hashpw(b"password123", bcrypt.gensalt()).decode()
+    }
+}
+
+def create_access_token(data: dict):
+    """Create a JWT token."""
+    to_encode = data.copy()
+    expire = datetime.utcnow() + timedelta(minutes=ACCESS_TOKEN_EXPIRE_MINUTES)
+    to_encode.update({"exp": expire})
+    return jwt.encode(to_encode, SECRET_KEY, algorithm=ALGORITHM)
+
+def verify_token(token: str):
+    """Verify and decode a JWT token."""
+    try:
+        payload = jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])
+        username: str = payload.get("sub")
+        if username is None:
+            raise HTTPException(status_code=401, detail="Invalid token")
+        return username
+    except jwt.ExpiredSignatureError:
+        raise HTTPException(status_code=401, detail="Token expired")
+    except jwt.JWTError:
+        raise HTTPException(status_code=401, detail="Invalid token")
+
+def get_current_user(credentials: HTTPAuthorizationCredentials = Depends(security)):
+    """FastAPI dependency that extracts and validates the current user."""
+    return verify_token(credentials.credentials)
+
+@app.post("/login", response_model=Token)
+async def login(user: User):
+    """Authenticate and return a JWT token."""
+    db_user = fake_users_db.get(user.username)
+
+    if not db_user:
+        raise HTTPException(status_code=401, detail="Invalid credentials")
+
+    if not bcrypt.checkpw(user.password.encode(), db_user["password_hash"].encode()):
+        raise HTTPException(status_code=401, detail="Invalid credentials")
+
+    access_token = create_access_token(data={"sub": user.username})
+    return Token(access_token=access_token, token_type="bearer")
+
+@app.post("/chat")
+async def chat(
+    request: ChatRequest,
+    current_user: str = Depends(get_current_user)
+):
+    """Protected chat endpoint — requires authentication."""
+    # current_user is automatically extracted from the token
+    # Use it to scope conversations to the authenticated user
+    # ... your chatbot logic ...
+    return {"response": "Hello!", "user": current_user}
+
+@app.get("/me")
+async def get_user_info(current_user: str = Depends(get_current_user)):
+    """Return the current user's information."""
+    return {"username": current_user}
+```
+
+The `get_current_user` function is a FastAPI dependency. By including `current_user: str = Depends(get_current_user)` in any endpoint's parameters, FastAPI automatically extracts the token from the `Authorization` header, validates it, and provides the username to the endpoint function. If the token is missing, expired, or invalid, FastAPI returns a 401 error before the endpoint logic runs.
+
+Client usage looks like this:
+
+```python
+import requests
+
+# Login to get a token
+response = requests.post("http://localhost:8000/login", json={
+    "username": "demo",
+    "password": "password123"
+})
+token = response.json()["access_token"]
+
+# Use the token for subsequent requests
+headers = {"Authorization": f"Bearer {token}"}
+
+chat_response = requests.post(
+    "http://localhost:8000/chat",
+    json={"message": "Hello!"},
+    headers=headers
+)
+```
+
+For a production system, you would add several enhancements: a real user database (PostgreSQL or similar), refresh tokens for long sessions (so users don't need to re-login every 60 minutes), password strength requirements, rate limiting on the login endpoint to prevent brute-force attacks, and account lockout after repeated failed attempts.
+
+## Managing Secrets and Environment Variables
+
+One of the most common security mistakes is hardcoding secrets — API keys, database passwords, JWT signing keys — directly in source code. If the code is pushed to a public repository or the Docker image is inspected, the secrets are exposed.
+
+The correct approach uses environment variables. In code, read secrets from the environment:
+
+```python
+from dotenv import load_dotenv
+import os
+
+load_dotenv()  # Load from .env file for local development
+
+openai_key = os.getenv("OPENAI_API_KEY")
+database_url = os.getenv("DATABASE_URL")
+secret_key = os.getenv("SECRET_KEY")
+```
+
+For local development, store secrets in a `.env` file:
+
+```
+OPENAI_API_KEY=sk-abc123...
+DATABASE_URL=postgresql://user:pass@localhost/chatbot
+SECRET_KEY=your-jwt-secret
+ENVIRONMENT=development
+```
+
+This file must never be committed to version control. Add it to `.gitignore`:
+
+```
+.env
+.env.local
+.env.*.local
+```
+
+For production, use your cloud provider's secret management service. These services encrypt secrets at rest, provide fine-grained access control, maintain audit logs of who accessed what, and support automatic secret rotation.
+
+```bash
+# AWS Secrets Manager
+aws secretsmanager create-secret \
+  --name chatbot/openai-key \
+  --secret-string sk-abc123...
+
+# Google Secret Manager
+gcloud secrets create openai-key \
+  --data-file=- <<< "sk-abc123..."
+
+# Azure Key Vault
+az keyvault secret set \
+  --vault-name myvault \
+  --name openai-key \
+  --value sk-abc123...
+```
+
+You can also pass environment variables directly during deployment:
+
+```bash
+# Cloud Run
+gcloud run deploy chatbot-api \
+  --set-env-vars OPENAI_API_KEY=sk-...
+
+# Kubernetes
+kubectl create secret generic chatbot-secrets \
+  --from-literal=openai-key=sk-...
+```
+
+To access secrets from a cloud secret manager in your application code:
+
+```python
+import boto3
+
+def get_secret(secret_name):
+    """Retrieve a secret from AWS Secrets Manager."""
+    client = boto3.client('secretsmanager')
+    response = client.get_secret_value(SecretId=secret_name)
+    return response['SecretString']
+
+openai_key = get_secret("chatbot/openai-key")
+```
+
+The principle is simple: secrets should never appear in source code, Docker images, or version control. They should be injected at runtime through environment variables or retrieved from a secret manager.
+
+::::challenge{id=m5-05-ex1 title="Deploy Your Chatbot"}
+
+Build a complete deployment stack for your capstone chatbot.
+
+**Step 1: Backend API (30 minutes).** Create a FastAPI application with `/chat`, `/health`, and `/conversations` endpoints. Use Pydantic models for request/response validation. Verify the auto-generated documentation at `/docs`.
+
+**Step 2: Frontend (20 minutes).** Build a Streamlit interface that communicates with your FastAPI backend. Implement chat history display, message input, and a clear conversation button.
+
+**Step 3: Docker (20 minutes).** Write a Dockerfile for your backend. Create a `docker-compose.yml` that runs both the backend and a PostgreSQL database. Verify the stack starts with `docker-compose up`.
+
+**Step 4: Cloud Deployment (15 minutes).** Deploy your backend to Google Cloud Run (or an alternative platform like Render). Verify the deployed URL responds to requests.
+
+**Step 5 (Bonus): Authentication (15 minutes).** Add JWT authentication to your API. Implement a `/login` endpoint and protect the `/chat` endpoint.
+::::
+
+::::challenge{id=m5-05-ex2 title="Project Checkpoint 5: Deploy Your Chatbot"}
+
+Your capstone project should now be a fully deployed application accessible via a public URL.
+
+Deliverables:
+
+- FastAPI backend with properly designed endpoints (`/chat`, `/health`, `/conversations`)
+- Frontend interface (Streamlit or React) connected to the backend
+- Dockerfile and `docker-compose.yml` for local development
+- Deployed backend with a public URL
+- Environment variables and secrets properly managed (not hardcoded)
+- (Bonus) JWT authentication on protected endpoints
+- Deployment documentation: setup instructions, API documentation (Swagger), and deployment guide
+
+Test your deployment against this checklist:
+
+1. The API responds correctly to chat requests.
+2. The frontend communicates with the backend and displays responses.
+3. Docker containers start without errors using `docker-compose up`.
+4. The deployed URL is accessible from the internet.
+5. No secrets are hardcoded in source code or Docker images.
+6. The health check endpoint returns a successful response.
+::::
+
+## Summary and What's Next
+
+In this module, you've taken your chatbot from a local script to a deployed application. You designed a RESTful API with FastAPI, providing a clean interface for clients to interact with your chatbot. You built frontend interfaces — Streamlit for rapid prototyping and React for production — that connect to the API. You containerised the application with Docker, ensuring it runs identically everywhere. You deployed it to the cloud, making it accessible to users on the internet. And you secured it with JWT authentication and proper secret management.
+
+In Module 6, you'll focus on understanding how your deployed chatbot is performing. You'll implement analytics to track user engagement, conversation quality, and system performance. You'll set up logging and monitoring to detect issues before users report them. And you'll build A/B testing frameworks to measure the impact of changes to your chatbot's behaviour.
+
+## Additional Resources
+
+- [FastAPI Documentation](https://fastapi.tiangolo.com/) — Comprehensive guide to FastAPI features
+- [Docker Documentation](https://docs.docker.com/) — Official Docker reference
+- ["The Twelve-Factor App"](https://12factor.net/) — Principles for building modern, deployable applications
+- [Google Cloud Run Documentation](https://cloud.google.com/run/docs) — Cloud Run setup and configuration
+- ["Building Microservices"](https://www.oreilly.com/library/view/building-microservices-2nd/9781492034018/) by Sam Newman — Architecture patterns for distributed systems
+- [Postman](https://www.postman.com/) — API testing and documentation tool

--- a/technology_and_tooling/chatbot_development/m5-05-authentication-and-security.md
+++ b/technology_and_tooling/chatbot_development/m5-05-authentication-and-security.md
@@ -11,6 +11,7 @@ attribution:
   - citation: >
       Oxford AI Competency Centre (2026). Chatbot Development Course.
     url: https://github.com/OxfordCompetencyCenters/aicc_chatbot_modules
+    image: https://github.com/OxfordCompetencyCenters.png
     license: CC-BY-4.0
 ---
 

--- a/technology_and_tooling/chatbot_development/m6-01-user-engagement-metrics.md
+++ b/technology_and_tooling/chatbot_development/m6-01-user-engagement-metrics.md
@@ -1,0 +1,152 @@
+---
+name: User Engagement Metrics
+dependsOn:
+  - technology_and_tooling.chatbot_development.m5-05-authentication-and-security
+tags: [chatbots, analytics, engagement, metrics, optional]
+learningOutcomes:
+  - Define and calculate key engagement metrics for chatbot applications.
+  - Implement an engagement tracking system that logs messages and sessions.
+  - Calculate retention rates using cohort analysis.
+attribution:
+  - citation: >
+      Oxford AI Competency Centre (2026). Chatbot Development Course.
+    url: https://github.com/OxfordCompetencyCenters/aicc_chatbot_modules
+    license: CC-BY-4.0
+---
+
+Your chatbot is deployed and users are interacting with it. But how is it actually performing? Are users finding value? Do they return? Where do they drop off? Without analytics, you're operating blind — making changes based on intuition rather than evidence, unable to tell whether an update improved the experience or degraded it.
+
+Analytics separates good chatbots from great ones. The metrics covered in this module give you a quantitative understanding of user behaviour, conversation quality, system performance, and the impact of changes. By the end, every decision you make about your chatbot will be grounded in data.
+
+## Key Engagement Metrics
+
+Engagement metrics answer the fundamental question: are people using your chatbot, and do they find it useful enough to come back?
+
+**Active users** measure the size and consistency of your user base. Daily Active Users (DAU) counts unique users per day. Weekly and Monthly Active Users (WAU, MAU) provide broader views. The ratio DAU/MAU — called "stickiness" — reveals how frequently users return. A stickiness ratio of 0.5 means the average monthly user engages on 15 out of 30 days, which is exceptionally high. For most chatbots, a stickiness ratio of 0.1–0.2 is healthy.
+
+**Session metrics** describe the depth of individual interactions. Session duration measures how long users engage in a single conversation. Messages per session measures how many exchanges occur. Sessions per user measures how often users return. Together, these paint a picture of usage patterns: are users having brief, transactional exchanges (1–2 messages) or extended, substantive conversations (10+ messages)?
+
+**Retention** is the most important engagement metric. It measures whether users come back. Day 1 retention is the percentage of users who return the next day. Day 7 and Day 30 retention track weekly and monthly return rates. For customer support chatbots, good benchmarks are 30–40% day-1 retention, 15–25% day-7 retention, and average sessions of 6–10 messages lasting 3–5 minutes. If your day-1 retention is below 15% or more than half of sessions consist of a single message, users aren't finding enough value to continue the conversation.
+
+## Implementing Engagement Tracking
+
+The foundation of engagement analytics is logging every message to a database where it can be queried later. The `EngagementTracker` class provides the core tracking and calculation capabilities:
+
+```python
+from datetime import datetime, timedelta
+from collections import defaultdict
+
+class EngagementTracker:
+    def __init__(self, db_connection):
+        self.db = db_connection
+
+    def log_message(self, user_id, session_id, role, content, timestamp=None):
+        """Log every message for analytics."""
+        if timestamp is None:
+            timestamp = datetime.now()
+
+        self.db.execute("""
+            INSERT INTO messages (user_id, session_id, role, content, timestamp)
+            VALUES (?, ?, ?, ?, ?)
+        """, (user_id, session_id, role, content, timestamp))
+
+    def get_daily_active_users(self, date):
+        """Count unique users who sent messages on a date."""
+        result = self.db.execute("""
+            SELECT COUNT(DISTINCT user_id)
+            FROM messages
+            WHERE DATE(timestamp) = ?
+        """, (date,))
+        return result.fetchone()[0]
+
+    def get_retention(self, cohort_date, days_later):
+        """Calculate retention for a cohort of users.
+
+        Args:
+            cohort_date: The date to analyse (e.g., "2024-01-01")
+            days_later: Days after cohort_date to check (e.g., 1, 7, 30)
+        """
+        cohort_users = self.db.execute("""
+            SELECT DISTINCT user_id
+            FROM messages
+            WHERE DATE(timestamp) = ?
+        """, (cohort_date,)).fetchall()
+
+        cohort_size = len(cohort_users)
+        if cohort_size == 0:
+            return 0
+
+        target_date = (datetime.strptime(cohort_date, "%Y-%m-%d") +
+                      timedelta(days=days_later)).strftime("%Y-%m-%d")
+
+        returned_users = self.db.execute("""
+            SELECT COUNT(DISTINCT user_id)
+            FROM messages
+            WHERE user_id IN ({})
+              AND DATE(timestamp) = ?
+        """.format(','.join('?' * cohort_size)),
+        tuple([u[0] for u in cohort_users] + [target_date])).fetchone()[0]
+
+        return (returned_users / cohort_size) * 100
+
+    def get_session_stats(self, session_id):
+        """Get statistics for a conversation session."""
+        messages = self.db.execute("""
+            SELECT role, content, timestamp
+            FROM messages
+            WHERE session_id = ?
+            ORDER BY timestamp
+        """, (session_id,)).fetchall()
+
+        if not messages:
+            return None
+
+        first_msg = datetime.fromisoformat(messages[0][2])
+        last_msg = datetime.fromisoformat(messages[-1][2])
+        duration = (last_msg - first_msg).total_seconds()
+
+        return {
+            "message_count": len(messages),
+            "duration_seconds": duration,
+            "user_messages": sum(1 for m in messages if m[0] == 'user'),
+            "bot_messages": sum(1 for m in messages if m[0] == 'assistant')
+        }
+
+    def get_engagement_report(self, start_date, end_date):
+        """Generate a comprehensive engagement report."""
+        dau = self.get_daily_active_users(end_date)
+
+        sessions = self.db.execute("""
+            SELECT session_id FROM messages
+            WHERE DATE(timestamp) BETWEEN ? AND ?
+            GROUP BY session_id
+        """, (start_date, end_date)).fetchall()
+
+        session_stats = [self.get_session_stats(s[0]) for s in sessions]
+        avg_duration = sum(s['duration_seconds'] for s in session_stats) / len(session_stats)
+        avg_messages = sum(s['message_count'] for s in session_stats) / len(session_stats)
+
+        return {
+            "dau": dau,
+            "total_sessions": len(sessions),
+            "avg_session_duration": avg_duration,
+            "avg_messages_per_session": avg_messages
+        }
+```
+
+Integrating the tracker into your API is straightforward — log every message that passes through the chat endpoint:
+
+```python
+tracker = EngagementTracker(db_connection)
+
+@app.post("/chat")
+async def chat(request: ChatRequest):
+    # ... generate response ...
+
+    tracker.log_message(request.user_id, session_id, "user", request.message)
+    tracker.log_message(request.user_id, session_id, "assistant", response)
+
+    return response
+```
+
+The principle is to log everything at the message level, then calculate metrics from the raw data. This gives you maximum flexibility — you can compute new metrics later without modifying the tracking code. In a production system, you would use a dedicated analytics database (ClickHouse, BigQuery) or an analytics service (Mixpanel, Amplitude) rather than querying the application database directly. The retention calculation is particularly valuable: it identifies which acquisition channels, features, or time periods produce users who stick around, and that insight directly informs where to invest your effort.

--- a/technology_and_tooling/chatbot_development/m6-01-user-engagement-metrics.md
+++ b/technology_and_tooling/chatbot_development/m6-01-user-engagement-metrics.md
@@ -11,6 +11,7 @@ attribution:
   - citation: >
       Oxford AI Competency Centre (2026). Chatbot Development Course.
     url: https://github.com/OxfordCompetencyCenters/aicc_chatbot_modules
+    image: https://github.com/OxfordCompetencyCenters.png
     license: CC-BY-4.0
 ---
 

--- a/technology_and_tooling/chatbot_development/m6-02-conversation-analytics.md
+++ b/technology_and_tooling/chatbot_development/m6-02-conversation-analytics.md
@@ -1,0 +1,173 @@
+---
+name: Conversation Analytics
+dependsOn:
+  - technology_and_tooling.chatbot_development.m6-01-user-engagement-metrics
+tags: [chatbots, analytics, conversation-quality, intent-analysis, optional]
+learningOutcomes:
+  - Measure conversation quality using fallback rate, goal completion, and abandonment metrics.
+  - Cluster user queries to discover common intents and coverage gaps.
+  - Map conversation flows to identify drop-off points and failure patterns.
+attribution:
+  - citation: >
+      Oxford AI Competency Centre (2026). Chatbot Development Course.
+    url: https://github.com/OxfordCompetencyCenters/aicc_chatbot_modules
+    license: CC-BY-4.0
+---
+
+Engagement metrics tell you how much people use your chatbot. Conversation analytics tell you how well the chatbot actually serves them. A bot can have high DAU while consistently failing to answer questions — users keep trying, get frustrated, and eventually leave. Understanding conversation quality requires measuring where conversations succeed, where they fail, and what users are actually asking about.
+
+## Conversation Quality Metrics
+
+Five metrics capture the core dimensions of conversation quality.
+
+**Fallback rate** is the percentage of conversations where the bot produces a response equivalent to "I don't understand" or "I can't help with that." A fallback rate below 10% is good; above 25% is concerning and suggests the bot's knowledge base or retrieval system has significant gaps. Tracking which specific queries trigger fallbacks reveals exactly where to focus improvement efforts.
+
+**Goal completion rate** measures the percentage of conversations where the user achieves their objective — an issue resolved, a product found, a question answered. This requires defining what "completion" means for your use case, which may involve explicit signals (user clicks "resolved"), implicit signals (user doesn't re-open the conversation), or LLM-based assessment. A completion rate above 70% is good; below 40% indicates serious problems.
+
+**Escalation rate** tracks the percentage of conversations handed off to a human agent. A lower rate generally means the bot is handling more queries autonomously, but pushing escalation rate to zero at the cost of user satisfaction is counterproductive. Below 15% is a good target; above 30% suggests the bot isn't capable enough for the queries it receives.
+
+**Response relevance** assesses how well the bot's answers match the user's questions. This can be measured through explicit user feedback (thumbs up/down, star ratings) or automated evaluation using an LLM as a judge. An average rating above 4.0 out of 5 is the target.
+
+**Conversation abandonment** tracks where users stop responding mid-conversation. A user who asks a question, receives an answer, and leaves naturally is fine. A user who asks three questions, gets increasingly irrelevant answers, and gives up represents a failure. Analysing which bot responses precede abandonment reveals the specific answers that are driving users away.
+
+The SQL query to find the most common failure points is revealing:
+
+```sql
+SELECT user_message, COUNT(*) as frequency
+FROM conversations
+WHERE next_message IS NULL
+  AND session_messages < 5
+GROUP BY user_message
+ORDER BY frequency DESC
+LIMIT 20
+```
+
+This surfaces the messages that most frequently cause users to leave early. Each one is a specific opportunity for improvement: a question the bot can't answer, a response that confuses users, or a topic where the knowledge base is inadequate.
+
+## Intent Coverage Analysis
+
+Understanding what users actually want from your chatbot is essential for prioritising improvements. Intent analysis uses clustering to group similar user queries together, revealing the most common topics and identifying gaps in coverage.
+
+```python
+from sklearn.feature_extraction.text import TfidfVectorizer
+from sklearn.cluster import KMeans
+
+class IntentAnalyzer:
+    def __init__(self, n_clusters=20):
+        self.vectorizer = TfidfVectorizer(max_features=100, stop_words='english')
+        self.kmeans = KMeans(n_clusters=n_clusters, random_state=42)
+
+    def analyze_user_queries(self, queries):
+        """Cluster user queries to identify common intents."""
+        X = self.vectorizer.fit_transform(queries)
+        clusters = self.kmeans.fit_predict(X)
+
+        cluster_info = {}
+        for cluster_id in range(self.kmeans.n_clusters):
+            cluster_queries = [q for i, q in enumerate(queries)
+                             if clusters[i] == cluster_id]
+
+            cluster_center = self.kmeans.cluster_centers_[cluster_id]
+            top_terms_idx = cluster_center.argsort()[-5:][::-1]
+            top_terms = [self.vectorizer.get_feature_names_out()[i]
+                        for i in top_terms_idx]
+
+            cluster_info[cluster_id] = {
+                "size": len(cluster_queries),
+                "top_terms": top_terms,
+                "sample_queries": cluster_queries[:5]
+            }
+
+        return cluster_info
+```
+
+Running this against a month of user queries might produce output like:
+
+```
+Cluster 0 (450 queries):
+  Topics: password, reset, login, account, forgot
+  Examples: ['How do I reset my password?', 'Forgot my login', "Can't access my account"]
+
+Cluster 1 (320 queries):
+  Topics: pricing, cost, plan, subscription, upgrade
+  Examples: ['What does the pro plan cost?', 'How much is an upgrade?', ...]
+```
+
+This is directly actionable. If 30% of queries are about password resets, improving that flow should be the top priority. If 20% ask about pricing but the knowledge base doesn't include pricing information, that's a clear gap to fill. Clusters with low goal completion rates are where improvement effort will have the biggest impact.
+
+For more sophisticated intent analysis, you can use BERT embeddings with HDBSCAN clustering or LLM-based classification. The TF-IDF approach shown here is a solid starting point that works well for initial exploration.
+
+## Conversation Flow Mapping
+
+Journey mapping visualises how users navigate conversations. By building a directed graph of conversation flows — where nodes are intents or message types and edges represent transitions — you can see the most common paths, identify dead ends, and spot loops where users rephrase the same question because the bot didn't answer it.
+
+```python
+import networkx as nx
+import matplotlib.pyplot as plt
+
+def build_conversation_graph(conversations):
+    """Build a graph of conversation flows."""
+    graph = nx.DiGraph()
+
+    for conv in conversations:
+        messages = conv['messages']
+
+        for i in range(len(messages) - 1):
+            current = messages[i]['intent']
+            next_msg = messages[i + 1]['intent']
+
+            if graph.has_edge(current, next_msg):
+                graph[current][next_msg]['weight'] += 1
+            else:
+                graph.add_edge(current, next_msg, weight=1)
+
+    return graph
+
+def find_drop_off_points(graph):
+    """Identify where users abandon conversations."""
+    drop_offs = []
+
+    for node in graph.nodes():
+        out_degree = graph.out_degree(node)
+        in_degree = graph.in_degree(node)
+
+        if in_degree > 10 and out_degree < 3:
+            drop_offs.append({
+                "node": node,
+                "in_degree": in_degree,
+                "out_degree": out_degree,
+                "drop_off_rate": 1 - (out_degree / in_degree)
+            })
+
+    return sorted(drop_offs, key=lambda x: x['in_degree'], reverse=True)
+```
+
+The `find_drop_off_points` function identifies nodes in the graph where many conversations arrive (high in-degree) but few continue (low out-degree). These are the points where users give up. A typical finding might be: "40% of users who ask about refunds don't respond to the next message." That tells you the refund response is inadequate and needs improvement.
+
+Loops in the graph — where users cycle back to the same node repeatedly — indicate frustration. The user is rephrasing their question because the bot didn't understand or didn't provide a useful answer. These loops are high-priority targets for improvement because the user is clearly motivated (they keep trying) but the bot is failing them.
+
+Visualising the graph with the most common paths highlighted gives you a map of the "happy paths" through your chatbot:
+
+```python
+def visualize_top_paths(graph, top_n=10):
+    """Visualise the most common conversation paths."""
+    edges = [(u, v, data['weight']) for u, v, data in graph.edges(data=True)]
+    top_edges = sorted(edges, key=lambda x: x[2], reverse=True)[:top_n]
+
+    subgraph = nx.DiGraph()
+    for u, v, weight in top_edges:
+        subgraph.add_edge(u, v, weight=weight)
+
+    pos = nx.spring_layout(subgraph)
+    nx.draw(subgraph, pos, with_labels=True, node_color='lightblue',
+            node_size=2000, font_size=8, arrows=True)
+
+    edge_labels = {(u, v): data['weight']
+                  for u, v, data in subgraph.edges(data=True)}
+    nx.draw_networkx_edge_labels(subgraph, pos, edge_labels)
+
+    plt.title("Top Conversation Paths")
+    plt.show()
+```
+
+This analysis directly informs product decisions. The most-travelled happy paths should be optimised for speed and clarity. Dead ends need better responses or escalation options. Loops need the underlying question to be answered properly. The resulting improvements are measurable through the same quality metrics, creating a closed feedback loop between analytics and product development.

--- a/technology_and_tooling/chatbot_development/m6-02-conversation-analytics.md
+++ b/technology_and_tooling/chatbot_development/m6-02-conversation-analytics.md
@@ -11,6 +11,7 @@ attribution:
   - citation: >
       Oxford AI Competency Centre (2026). Chatbot Development Course.
     url: https://github.com/OxfordCompetencyCenters/aicc_chatbot_modules
+    image: https://github.com/OxfordCompetencyCenters.png
     license: CC-BY-4.0
 ---
 

--- a/technology_and_tooling/chatbot_development/m6-03-performance-monitoring.md
+++ b/technology_and_tooling/chatbot_development/m6-03-performance-monitoring.md
@@ -1,0 +1,203 @@
+---
+name: Performance Monitoring
+dependsOn:
+  - technology_and_tooling.chatbot_development.m6-02-conversation-analytics
+tags: [chatbots, analytics, performance, latency, cost-tracking, optional]
+learningOutcomes:
+  - Track response latency at the component level using percentile metrics.
+  - Implement cost tracking for LLM API usage across models.
+  - Identify performance bottlenecks and apply targeted optimisations.
+attribution:
+  - citation: >
+      Oxford AI Competency Centre (2026). Chatbot Development Course.
+    url: https://github.com/OxfordCompetencyCenters/aicc_chatbot_modules
+    license: CC-BY-4.0
+---
+
+User engagement and conversation quality metrics measure the experience from the user's perspective. Performance monitoring measures the system from the engineering perspective: how fast are responses, how much do they cost, and where are the bottlenecks? These metrics directly impact user satisfaction (nobody wants to wait 10 seconds for a response) and your budget (LLM API costs can spiral quickly at scale).
+
+## Latency Tracking
+
+Users expect chatbot responses within 2–3 seconds. Beyond 5 seconds, the experience starts to feel slow. Beyond 10 seconds, users begin to abandon conversations. To meet these targets, you need to know exactly where time is being spent in each request.
+
+The key latency metrics are percentiles rather than averages. The median (p50) shows the typical experience. The 95th percentile (p95) shows what 5% of users experience in the worst case. The 99th percentile (p99) shows extreme outliers. Good targets for a chatbot API are p50 under 2 seconds, p95 under 5 seconds, and p99 under 10 seconds. If p99 is dramatically higher than p95, you have outliers worth investigating — they might indicate timeout issues, cold starts, or specific query patterns that trigger expensive processing.
+
+The `PerformanceMonitor` class uses context managers to track latency at the component level:
+
+```python
+import time
+from collections import defaultdict
+import numpy as np
+
+class PerformanceMonitor:
+    def __init__(self):
+        self.latencies = defaultdict(list)
+
+    def track_latency(self, operation_name):
+        """Context manager to track latency of an operation."""
+        class LatencyTracker:
+            def __init__(self, monitor, name):
+                self.monitor = monitor
+                self.name = name
+                self.start_time = None
+
+            def __enter__(self):
+                self.start_time = time.time()
+                return self
+
+            def __exit__(self, *args):
+                duration = time.time() - self.start_time
+                self.monitor.record_latency(self.name, duration)
+
+        return LatencyTracker(self, operation_name)
+
+    def record_latency(self, name, duration):
+        """Record a latency measurement."""
+        self.latencies[name].append(duration)
+        if len(self.latencies[name]) > 1000:
+            self.latencies[name] = self.latencies[name][-1000:]
+
+    def get_stats(self, name):
+        """Get latency statistics for an operation."""
+        if name not in self.latencies or not self.latencies[name]:
+            return None
+
+        latencies = np.array(self.latencies[name])
+        return {
+            "count": len(latencies),
+            "mean": np.mean(latencies),
+            "median": np.median(latencies),
+            "p95": np.percentile(latencies, 95),
+            "p99": np.percentile(latencies, 99),
+            "min": np.min(latencies),
+            "max": np.max(latencies)
+        }
+
+    def get_all_stats(self):
+        """Get stats for all tracked operations."""
+        return {name: self.get_stats(name) for name in self.latencies.keys()}
+```
+
+Wrapping each component of the chat endpoint with the tracker reveals where time is spent:
+
+```python
+monitor = PerformanceMonitor()
+
+@app.post("/chat")
+async def chat(request: ChatRequest):
+    with monitor.track_latency("total_request"):
+        with monitor.track_latency("rag_retrieval"):
+            documents = rag.retrieve(request.message)
+
+        with monitor.track_latency("llm_generation"):
+            response = llm.generate(documents, request.message)
+
+        with monitor.track_latency("memory_update"):
+            memory.store(request.user_id, request.message, response)
+
+    return {"response": response}
+
+@app.get("/metrics/latency")
+async def get_latency_metrics():
+    """Expose latency metrics for monitoring."""
+    stats = monitor.get_all_stats()
+    return {
+        operation: {
+            "mean_ms": s["mean"] * 1000,
+            "p95_ms": s["p95"] * 1000,
+            "p99_ms": s["p99"] * 1000
+        }
+        for operation, s in stats.items()
+    }
+```
+
+A typical breakdown might look like:
+
+```
+total_request:    mean 2340ms, p95 4500ms, p99 7200ms
+rag_retrieval:    mean  450ms, p95  800ms, p99 1200ms
+llm_generation:   mean 1800ms, p95 3500ms, p99 6000ms
+memory_update:    mean   90ms, p95  150ms, p99  200ms
+```
+
+This breakdown makes optimisation decisions clear. LLM generation accounts for 77% of the total time. Optimising the RAG retrieval — which takes only 19% — won't meaningfully improve the user experience. The high-impact options are: using a faster model (GPT-3.5 instead of GPT-4), reducing the prompt length to lower generation time, or implementing streaming so the user sees tokens appear immediately even though total generation time is unchanged.
+
+## Cost Tracking
+
+LLM API costs are typically the largest operational expense for a chatbot. Without tracking, costs can spiral unexpectedly — a change that increases average prompt length by 200 tokens might seem minor, but at 10,000 requests per day it adds up to significant monthly spend.
+
+The `CostTracker` class records token usage per model and calculates costs based on current pricing:
+
+```python
+class CostTracker:
+    COSTS = {
+        "gpt-3.5-turbo": {"input": 0.0005, "output": 0.0015},
+        "gpt-4": {"input": 0.03, "output": 0.06},
+        "embedding-3-small": {"input": 0.00002, "output": 0}
+    }
+
+    def __init__(self):
+        self.usage = defaultdict(
+            lambda: {"input_tokens": 0, "output_tokens": 0, "calls": 0}
+        )
+
+    def record_usage(self, model, input_tokens, output_tokens):
+        """Record API usage for a request."""
+        self.usage[model]["input_tokens"] += input_tokens
+        self.usage[model]["output_tokens"] += output_tokens
+        self.usage[model]["calls"] += 1
+
+    def calculate_cost(self, model, input_tokens, output_tokens):
+        """Calculate the dollar cost for a request."""
+        pricing = self.COSTS.get(model, {"input": 0, "output": 0})
+        input_cost = (input_tokens / 1000) * pricing["input"]
+        output_cost = (output_tokens / 1000) * pricing["output"]
+        return input_cost + output_cost
+
+    def get_cost_breakdown(self):
+        """Get cost breakdown by model."""
+        breakdown = {}
+        for model, usage in self.usage.items():
+            cost = self.calculate_cost(
+                model, usage["input_tokens"], usage["output_tokens"]
+            )
+            breakdown[model] = {
+                "total_cost": cost,
+                "calls": usage["calls"],
+                "cost_per_call": cost / usage["calls"] if usage["calls"] > 0 else 0,
+                "input_tokens": usage["input_tokens"],
+                "output_tokens": usage["output_tokens"]
+            }
+        return breakdown
+```
+
+Integrating this into the chat endpoint captures costs automatically:
+
+```python
+cost_tracker = CostTracker()
+
+@app.post("/chat")
+async def chat(request: ChatRequest):
+    response = openai.ChatCompletion.create(
+        model="gpt-3.5-turbo",
+        messages=messages
+    )
+
+    usage = response.usage
+    cost_tracker.record_usage(
+        "gpt-3.5-turbo",
+        usage.prompt_tokens,
+        usage.completion_tokens
+    )
+
+    cost = cost_tracker.calculate_cost(
+        "gpt-3.5-turbo",
+        usage.prompt_tokens,
+        usage.completion_tokens
+    )
+    logger.info(f"Request cost: ${cost:.4f}")
+
+    return {"response": response.choices[0].message.content}
+```
+
+The cost breakdown reveals optimisation opportunities. If GPT-3.5 accounts for 84% of total costs despite its lower per-token price, it's because it handles 67 times more requests than GPT-4. The key cost optimisation strategies are: using the cheapest model that meets quality requirements for each query type, implementing semantic caching to avoid re-processing similar queries (covered in Module 3), trimming unnecessary conversation history from prompts, batching embedding requests, and setting `max_tokens` limits to prevent runaway generations. Budget alerts are also essential — configure your system to alert you if daily costs exceed a threshold, so a traffic spike or a bug that generates excessively long prompts doesn't drain your budget before you notice.

--- a/technology_and_tooling/chatbot_development/m6-03-performance-monitoring.md
+++ b/technology_and_tooling/chatbot_development/m6-03-performance-monitoring.md
@@ -11,6 +11,7 @@ attribution:
   - citation: >
       Oxford AI Competency Centre (2026). Chatbot Development Course.
     url: https://github.com/OxfordCompetencyCenters/aicc_chatbot_modules
+    image: https://github.com/OxfordCompetencyCenters.png
     license: CC-BY-4.0
 ---
 

--- a/technology_and_tooling/chatbot_development/m6-03-performance-monitoring.md
+++ b/technology_and_tooling/chatbot_development/m6-03-performance-monitoring.md
@@ -1,7 +1,7 @@
 ---
 name: Performance Monitoring
 dependsOn:
-  - technology_and_tooling.chatbot_development.m6-02-conversation-analytics
+  - technology_and_tooling.chatbot_development.m6-01-user-engagement-metrics
 tags: [chatbots, analytics, performance, latency, cost-tracking, optional]
 learningOutcomes:
   - Track response latency at the component level using percentile metrics.

--- a/technology_and_tooling/chatbot_development/m6-04-logging-and-observability.md
+++ b/technology_and_tooling/chatbot_development/m6-04-logging-and-observability.md
@@ -1,7 +1,7 @@
 ---
 name: Logging and Observability
 dependsOn:
-  - technology_and_tooling.chatbot_development.m6-03-performance-monitoring
+  - technology_and_tooling.chatbot_development.m6-01-user-engagement-metrics
 tags: [chatbots, analytics, logging, observability, tracing, optional]
 learningOutcomes:
   - Implement structured JSON logging with trace IDs for production chatbot systems.

--- a/technology_and_tooling/chatbot_development/m6-04-logging-and-observability.md
+++ b/technology_and_tooling/chatbot_development/m6-04-logging-and-observability.md
@@ -11,6 +11,7 @@ attribution:
   - citation: >
       Oxford AI Competency Centre (2026). Chatbot Development Course.
     url: https://github.com/OxfordCompetencyCenters/aicc_chatbot_modules
+    image: https://github.com/OxfordCompetencyCenters.png
     license: CC-BY-4.0
 ---
 

--- a/technology_and_tooling/chatbot_development/m6-04-logging-and-observability.md
+++ b/technology_and_tooling/chatbot_development/m6-04-logging-and-observability.md
@@ -1,0 +1,202 @@
+---
+name: Logging and Observability
+dependsOn:
+  - technology_and_tooling.chatbot_development.m6-03-performance-monitoring
+tags: [chatbots, analytics, logging, observability, tracing, optional]
+learningOutcomes:
+  - Implement structured JSON logging with trace IDs for production chatbot systems.
+  - Set up distributed tracing with OpenTelemetry to visualise request flow.
+  - Design a logging strategy that balances detail with cost and performance.
+attribution:
+  - citation: >
+      Oxford AI Competency Centre (2026). Chatbot Development Course.
+    url: https://github.com/OxfordCompetencyCenters/aicc_chatbot_modules
+    license: CC-BY-4.0
+---
+
+Metrics tell you that something is wrong — latency increased, error rate spiked, cost jumped. Logs and traces tell you why. When a user reports that the chatbot gave a nonsensical answer, you need to reconstruct exactly what happened: what message did they send, what documents were retrieved, what prompt was constructed, what the LLM returned. Without structured logging, this investigation involves grepping through unstructured text files. With structured logging, it's a query on indexed fields.
+
+## Structured Logging
+
+The difference between unstructured and structured logging determines whether your logs are useful in production:
+
+```python
+# Unstructured — hard to search, impossible to aggregate
+logging.info(f"User {user_id} sent message: {message}")
+
+# Structured — searchable by any field, aggregatable
+logging.info("user_message_received", extra={
+    "user_id": user_id,
+    "session_id": session_id,
+    "message_length": len(message),
+    "timestamp": datetime.now().isoformat()
+})
+```
+
+Structured logs output JSON, which is natively parseable by log aggregation tools like Elasticsearch, CloudWatch, Datadog, and Grafana Loki. Every log entry has typed, named fields that you can filter, sort, and aggregate. This makes queries like "show me all requests where retrieval took longer than 1 second" or "find all errors for user X in the last hour" trivial.
+
+Here is a production logging setup using `python-json-logger`:
+
+```python
+import logging
+import os
+from datetime import datetime
+from pythonjsonlogger import jsonlogger
+
+class CustomJsonFormatter(jsonlogger.JsonFormatter):
+    """Custom JSON log formatter with service metadata."""
+
+    def add_fields(self, log_record, record, message_dict):
+        super().add_fields(log_record, record, message_dict)
+        log_record['timestamp'] = datetime.utcnow().isoformat()
+        log_record['service'] = 'chatbot-api'
+        log_record['environment'] = os.getenv('ENVIRONMENT', 'development')
+
+        if hasattr(record, 'trace_id'):
+            log_record['trace_id'] = record.trace_id
+
+logger = logging.getLogger()
+handler = logging.StreamHandler()
+formatter = CustomJsonFormatter('%(timestamp)s %(level)s %(name)s %(message)s')
+handler.setFormatter(formatter)
+logger.addHandler(handler)
+logger.setLevel(logging.INFO)
+```
+
+The key practice is to log at every decision point in the request lifecycle, with a trace ID that ties all logs from a single request together:
+
+```python
+@app.post("/chat")
+async def chat(request: ChatRequest):
+    trace_id = generate_trace_id()
+
+    logger.info("chat_request_received", extra={
+        "trace_id": trace_id,
+        "user_id": request.user_id,
+        "session_id": request.conversation_id,
+        "message_length": len(request.message)
+    })
+
+    try:
+        start = time.time()
+        documents = rag.retrieve(request.message)
+        retrieval_time = time.time() - start
+
+        logger.info("rag_retrieval_completed", extra={
+            "trace_id": trace_id,
+            "num_documents": len(documents),
+            "retrieval_time_ms": retrieval_time * 1000
+        })
+
+        start = time.time()
+        response = llm.generate(documents, request.message)
+        generation_time = time.time() - start
+
+        logger.info("llm_generation_completed", extra={
+            "trace_id": trace_id,
+            "response_length": len(response),
+            "generation_time_ms": generation_time * 1000,
+            "model": "gpt-3.5-turbo"
+        })
+
+        logger.info("chat_request_completed", extra={
+            "trace_id": trace_id,
+            "total_time_ms": (retrieval_time + generation_time) * 1000,
+            "status": "success"
+        })
+
+        return {"response": response, "trace_id": trace_id}
+
+    except Exception as e:
+        logger.error("chat_request_failed", extra={
+            "trace_id": trace_id,
+            "error": str(e),
+            "error_type": type(e).__name__
+        }, exc_info=True)
+        raise
+```
+
+Each log entry produces a JSON object like:
+
+```json
+{
+  "timestamp": "2024-01-15T10:30:45.123Z",
+  "level": "INFO",
+  "message": "rag_retrieval_completed",
+  "service": "chatbot-api",
+  "environment": "production",
+  "trace_id": "abc-123-def",
+  "num_documents": 5,
+  "retrieval_time_ms": 452.3
+}
+```
+
+When something goes wrong, you search by `trace_id` and see the complete lifecycle of that request: what was received, what was retrieved, how long generation took, and where it failed. The fields to include in every log entry are: `trace_id` (ties the request together), `user_id` (identifies who is affected), `session_id` (groups related requests), the operation name (what happened), `duration_ms` (how long it took), and `status` (success or failure with error details).
+
+A practical note on cost: log aggregation services charge by volume. Don't log the full text of every message and response — that can be enormous at scale. Log metadata (lengths, timings, IDs) and store full message content in your application database where it's needed for debugging specific issues.
+
+## Distributed Tracing with OpenTelemetry
+
+In a microservices architecture — where the chat request might pass through an API gateway, a retrieval service, an LLM proxy, and a memory service — structured logging alone isn't enough. You need distributed tracing to visualise how a single request flows across services.
+
+OpenTelemetry is the industry standard for distributed tracing. It creates spans for each operation, nests them to show the call hierarchy, and exports them to visualisation tools like Jaeger or Zipkin.
+
+```python
+from opentelemetry import trace
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
+from opentelemetry.exporter.jaeger import JaegerExporter
+from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
+
+trace.set_tracer_provider(TracerProvider())
+tracer = trace.get_tracer(__name__)
+
+jaeger_exporter = JaegerExporter(
+    agent_host_name="localhost",
+    agent_port=6831,
+)
+trace.get_tracer_provider().add_span_processor(
+    BatchSpanProcessor(jaeger_exporter)
+)
+
+# Automatically instrument all FastAPI endpoints
+FastAPIInstrumentor.instrument_app(app)
+
+# Add manual instrumentation for custom operations
+@app.post("/chat")
+async def chat(request: ChatRequest):
+    with tracer.start_as_current_span("chat_request") as span:
+        span.set_attribute("user_id", request.user_id)
+        span.set_attribute("message_length", len(request.message))
+
+        with tracer.start_as_current_span("rag_retrieval"):
+            documents = rag.retrieve(request.message)
+            span.set_attribute("documents_retrieved", len(documents))
+
+        with tracer.start_as_current_span("llm_generation"):
+            span.set_attribute("model", "gpt-3.5-turbo")
+            response = llm.generate(documents, request.message)
+            span.set_attribute("response_length", len(response))
+
+        with tracer.start_as_current_span("memory_update"):
+            memory.store(request.user_id, request.message, response)
+
+        span.set_attribute("status", "success")
+        return {"response": response}
+```
+
+In the Jaeger or Zipkin UI, a single request appears as a waterfall of nested spans:
+
+```
+Chat Request (2.4s)
+├─ RAG Retrieval (450ms)
+│  ├─ Vector Search (380ms)
+│  └─ Re-ranking (70ms)
+├─ LLM Generation (1.8s)
+│  └─ OpenAI API Call (1.75s)
+└─ Memory Update (150ms)
+   ├─ Database Write (100ms)
+   └─ Cache Update (50ms)
+```
+
+This visualisation makes bottlenecks obvious at a glance. The span attributes enable powerful filtering: "show traces where documents_retrieved is greater than 10" to isolate expensive retrieval operations, or "show traces where the LLM generation span exceeds 5 seconds" to investigate timeouts. For teams operating chatbots in production, distributed tracing is the single most valuable debugging tool — it turns opaque "the bot was slow" reports into specific, actionable engineering tasks.

--- a/technology_and_tooling/chatbot_development/m6-05-ab-testing-and-experimentation.md
+++ b/technology_and_tooling/chatbot_development/m6-05-ab-testing-and-experimentation.md
@@ -1,7 +1,7 @@
 ---
 name: A/B Testing and Experimentation
 dependsOn:
-  - technology_and_tooling.chatbot_development.m6-04-logging-and-observability
+  - technology_and_tooling.chatbot_development.m6-01-user-engagement-metrics
 tags: [chatbots, analytics, ab-testing, experimentation, optional]
 learningOutcomes:
   - Build a deterministic A/B testing framework for chatbot experiments.

--- a/technology_and_tooling/chatbot_development/m6-05-ab-testing-and-experimentation.md
+++ b/technology_and_tooling/chatbot_development/m6-05-ab-testing-and-experimentation.md
@@ -11,6 +11,7 @@ attribution:
   - citation: >
       Oxford AI Competency Centre (2026). Chatbot Development Course.
     url: https://github.com/OxfordCompetencyCenters/aicc_chatbot_modules
+    image: https://github.com/OxfordCompetencyCenters.png
     license: CC-BY-4.0
 ---
 

--- a/technology_and_tooling/chatbot_development/m6-05-ab-testing-and-experimentation.md
+++ b/technology_and_tooling/chatbot_development/m6-05-ab-testing-and-experimentation.md
@@ -1,0 +1,291 @@
+---
+name: A/B Testing and Experimentation
+dependsOn:
+  - technology_and_tooling.chatbot_development.m6-04-logging-and-observability
+tags: [chatbots, analytics, ab-testing, experimentation, optional]
+learningOutcomes:
+  - Build a deterministic A/B testing framework for chatbot experiments.
+  - Track experiment metrics and evaluate results with statistical significance.
+  - Apply A/B testing to optimise prompts, models, and retrieval strategies.
+attribution:
+  - citation: >
+      Oxford AI Competency Centre (2026). Chatbot Development Course.
+    url: https://github.com/OxfordCompetencyCenters/aicc_chatbot_modules
+    license: CC-BY-4.0
+---
+
+Analytics tells you how your chatbot is performing. A/B testing tells you whether a change makes it better. Without controlled experiments, you can't distinguish genuine improvements from noise — a metric might improve after a code change simply because of seasonal variation in traffic, not because the change was beneficial. A/B testing gives you scientific confidence that changes actually work.
+
+The types of changes worth A/B testing in a chatbot include different system prompts, RAG strategies (basic retrieval versus re-ranked), models (GPT-3.5 versus GPT-4 for specific query types), UI changes (different message layouts, input prompts), and response styles (concise versus detailed, formal versus casual).
+
+## Building an A/B Testing Framework
+
+The core of A/B testing is deterministic assignment: the same user must always see the same variant. If a user gets the "detailed prompt" on one request and the "concise prompt" on the next, the experiment is contaminated. Deterministic assignment is achieved by hashing the combination of user ID and experiment name:
+
+```python
+import hashlib
+from collections import defaultdict
+from datetime import datetime
+import numpy as np
+
+class ABTestManager:
+    def __init__(self):
+        self.experiments = {}
+
+    def create_experiment(self, experiment_name, variants, traffic_split):
+        """Create an A/B test.
+
+        Args:
+            experiment_name: Unique identifier for the experiment.
+            variants: Dict mapping variant names to their configurations.
+            traffic_split: Dict mapping variant names to percentage of traffic
+                          (must sum to 100).
+        """
+        self.experiments[experiment_name] = {
+            "variants": variants,
+            "traffic_split": traffic_split
+        }
+
+    def assign_variant(self, experiment_name, user_id):
+        """Deterministically assign a user to a variant."""
+        if experiment_name not in self.experiments:
+            return None
+
+        hash_input = f"{user_id}:{experiment_name}"
+        hash_value = int(hashlib.md5(hash_input.encode()).hexdigest(), 16)
+        percentage = hash_value % 100
+
+        traffic_split = self.experiments[experiment_name]["traffic_split"]
+        cumulative = 0
+
+        for variant, split in traffic_split.items():
+            cumulative += split
+            if percentage < cumulative:
+                return variant
+
+        return list(traffic_split.keys())[0]
+
+    def get_variant_config(self, experiment_name, user_id):
+        """Get the configuration for a user's assigned variant."""
+        variant = self.assign_variant(experiment_name, user_id)
+        if variant is None:
+            return None
+        return self.experiments[experiment_name]["variants"][variant]
+```
+
+Using this framework in a chat endpoint is straightforward:
+
+```python
+ab_test = ABTestManager()
+
+ab_test.create_experiment(
+    experiment_name="prompt_style",
+    variants={
+        "control": {
+            "system_prompt": "You are a helpful assistant."
+        },
+        "treatment": {
+            "system_prompt": "You are an expert assistant who provides detailed, "
+                           "well-structured answers."
+        }
+    },
+    traffic_split={"control": 50, "treatment": 50}
+)
+
+@app.post("/chat")
+async def chat(request: ChatRequest):
+    variant_config = ab_test.get_variant_config("prompt_style", request.user_id)
+    system_prompt = variant_config["system_prompt"]
+
+    logger.info("ab_test_assignment", extra={
+        "user_id": request.user_id,
+        "experiment": "prompt_style",
+        "variant": ab_test.assign_variant("prompt_style", request.user_id)
+    })
+
+    response = llm.generate(system_prompt=system_prompt, ...)
+    return {"response": response}
+```
+
+## Tracking Experiment Results
+
+Each experiment needs a tracker that records metrics per variant so you can compare them:
+
+```python
+class ExperimentTracker:
+    def __init__(self):
+        self.metrics = defaultdict(lambda: defaultdict(list))
+
+    def record_metric(self, experiment, variant, metric_name, value):
+        """Record a metric observation for an experiment variant."""
+        self.metrics[experiment][variant].append({
+            "metric": metric_name,
+            "value": value,
+            "timestamp": datetime.now()
+        })
+
+    def get_results(self, experiment):
+        """Get aggregated results for an experiment."""
+        results = {}
+
+        for variant, metrics in self.metrics[experiment].items():
+            by_metric = defaultdict(list)
+            for m in metrics:
+                by_metric[m["metric"]].append(m["value"])
+
+            variant_results = {}
+            for metric_name, values in by_metric.items():
+                variant_results[metric_name] = {
+                    "mean": np.mean(values),
+                    "std": np.std(values),
+                    "count": len(values)
+                }
+
+            results[variant] = variant_results
+
+        return results
+```
+
+Recording metrics in the chat endpoint ties each observation to the user's assigned variant:
+
+```python
+exp_tracker = ExperimentTracker()
+
+@app.post("/chat")
+async def chat(request: ChatRequest):
+    variant = ab_test.assign_variant("prompt_style", request.user_id)
+
+    start = time.time()
+    response = generate_response(...)
+    latency = time.time() - start
+
+    exp_tracker.record_metric("prompt_style", variant, "latency", latency)
+    exp_tracker.record_metric("prompt_style", variant, "response_length", len(response))
+
+    return response
+```
+
+After collecting sufficient data (typically 1,000 or more observations per variant), you can compare the results:
+
+```python
+results = exp_tracker.get_results("prompt_style")
+# {
+#   "control": {
+#     "latency": {"mean": 2.1, "std": 0.5, "count": 1543},
+#     "response_length": {"mean": 342, "std": 120, "count": 1543}
+#   },
+#   "treatment": {
+#     "latency": {"mean": 2.8, "std": 0.7, "count": 1521},
+#     "response_length": {"mean": 485, "std": 150, "count": 1521}
+#   }
+# }
+```
+
+In this example, the treatment variant produces longer responses (485 versus 342 characters) but takes longer (2.8 versus 2.1 seconds). Whether this is an improvement depends on which metric you optimise for. Longer responses might mean more thorough answers, but the increased latency degrades the user experience. You would need to measure engagement metrics (session length, return rate) for each variant to determine which one users actually prefer.
+
+To determine whether the observed differences are real or just noise, use a statistical significance test:
+
+```python
+from scipy import stats
+
+def is_significant(control_values, treatment_values, alpha=0.05):
+    """Check if the difference between variants is statistically significant."""
+    t_stat, p_value = stats.ttest_ind(control_values, treatment_values)
+    return {
+        "p_value": p_value,
+        "is_significant": p_value < alpha,
+        "effect_size": (np.mean(treatment_values) - np.mean(control_values))
+                      / np.std(control_values)
+    }
+```
+
+If the p-value is below 0.05, you can be 95% confident the difference is real. If the treatment is significantly better on the metrics you care about, roll it out to 100% of traffic. If it's significantly worse, kill the experiment. If the difference is not significant, either collect more data or accept that the change has no meaningful impact.
+
+For production A/B testing at scale, tools like LaunchDarkly, Optimizely, or GrowthBook provide feature flag management, automatic traffic splitting, and statistical analysis without requiring you to build the framework from scratch.
+
+::::challenge{id=m6-05-ex1 title="Engagement Tracking"}
+
+Implement the `EngagementTracker` class and integrate it into your chatbot API. Log all messages and generate a daily engagement report including DAU, average session duration, and messages per session. Calculate day-7 retention for a cohort of your choosing.
+::::
+
+::::challenge{id=m6-05-ex2 title="Performance Monitoring"}
+
+Add latency tracking to your chat endpoint, instrumenting each component (retrieval, generation, memory update) separately. Implement the `CostTracker` and create a `/metrics` endpoint that exposes both latency percentiles and cost breakdown.
+::::
+
+::::challenge{id=m6-05-ex3 title="Analytics Dashboard"}
+
+Build a Streamlit dashboard that displays your chatbot's key metrics:
+
+```python
+import streamlit as st
+import plotly.express as px
+
+st.title("Chatbot Analytics Dashboard")
+
+st.header("Engagement")
+col1, col2, col3 = st.columns(3)
+col1.metric("DAU", report['dau'])
+col2.metric("Avg Session Duration", f"{report['avg_duration']:.1f}s")
+col3.metric("Messages/Session", f"{report['avg_messages']:.1f}")
+
+st.header("Performance")
+latency_df = get_latency_timeseries()
+fig = px.line(latency_df, x="timestamp", y="p95_latency", title="P95 Latency")
+st.plotly_chart(fig)
+
+st.header("Costs")
+cost_breakdown = cost_tracker.get_cost_breakdown()
+# Visualise as a bar chart or table
+```
+
+Include engagement metrics, latency trends over time, cost breakdown by model, and conversation quality indicators.
+::::
+
+::::challenge{id=m6-05-ex4 title="A/B Test"}
+
+Set up an A/B test comparing two system prompts. Run at least 100 conversations through each variant and analyse the results. Report on which variant performs better and whether the difference is statistically significant.
+
+```python
+ab_test.create_experiment(
+    "system_prompt_test",
+    variants={
+        "control": {"prompt": "You are a helpful assistant."},
+        "treatment": {"prompt": "You are a knowledgeable expert."}
+    },
+    traffic_split={"control": 50, "treatment": 50}
+)
+```
+::::
+
+::::challenge{id=m6-05-checkpoint title="Project Checkpoint 6: Add Analytics"}
+
+Instrument your capstone project with a complete analytics system.
+
+Deliverables:
+
+- Engagement tracking: DAU, retention, session statistics
+- Performance monitoring: latency percentiles (p50/p95/p99), cost per request, total spend
+- Structured logging with trace IDs
+- Analytics dashboard (Streamlit or similar) with real-time or near-real-time updates, historical trends, and filterable time ranges
+- A/B test with at least 100 samples per variant, statistical significance analysis, and a decision (roll out or kill)
+- Documentation of your analytics strategy and findings
+::::
+
+## Summary and What's Next
+
+In this module, you've built a complete observability stack for your chatbot. You can now measure user engagement (who's using it, how often, and do they return), analyse conversation quality (where do conversations succeed and fail, what do users actually want), monitor performance (how fast and how expensive), trace individual requests across your entire system, and run controlled experiments to measure the impact of changes.
+
+Every improvement to your chatbot is now measurable. When you change a prompt, you can quantify the impact on engagement. When you optimise retrieval, you can verify the latency improvement. When you add a new feature, you can track whether users adopt it. This data-driven approach is what separates prototype chatbots from production systems.
+
+In Module 7, you'll apply production best practices to make your chatbot robust, safe, and cost-effective. You'll learn advanced prompt engineering for reliability, implement safety guardrails and content moderation, optimise costs at scale, and explore strategies for handling high traffic.
+
+## Additional Resources
+
+- ["Lean Analytics"](https://leananalyticsbook.com/) by Alistair Croll & Benjamin Yoskovitz — Choosing the right metrics for your stage
+- ["Trustworthy Online Controlled Experiments"](https://www.cambridge.org/core/books/trustworthy-online-controlled-experiments/D97B26382EB0EB2DC2019A7A7B518F59) by Kohavi, Tang & Xu — Comprehensive A/B testing guide
+- ["Observability Engineering"](https://www.oreilly.com/library/view/observability-engineering/9781492076438/) by Charity Majors, Liz Fong-Jones & George Miranda — Modern observability practices
+- [OpenTelemetry Documentation](https://opentelemetry.io/docs/) — Distributed tracing and metrics standard
+- [Prometheus](https://prometheus.io/) — Open-source monitoring and alerting
+- [Grafana](https://grafana.com/) — Dashboarding and visualisation
+- [Jaeger](https://www.jaegertracing.io/) — Distributed tracing backend

--- a/technology_and_tooling/chatbot_development/m7-01-production-prompt-engineering.md
+++ b/technology_and_tooling/chatbot_development/m7-01-production-prompt-engineering.md
@@ -1,0 +1,210 @@
+---
+name: Production Prompt Engineering
+dependsOn:
+  - technology_and_tooling.chatbot_development.m6-05-ab-testing-and-experimentation
+tags: [chatbots, prompt-engineering, production, optional]
+learningOutcomes:
+  - Apply structured prompt design patterns for production chatbots.
+  - Handle edge cases including out-of-scope queries, ambiguous input, and adversarial messages.
+  - Version-control and systematically test prompts before deployment.
+attribution:
+  - citation: >
+      Oxford AI Competency Centre (2026). Chatbot Development Course.
+    url: https://github.com/OxfordCompetencyCenters/aicc_chatbot_modules
+    license: CC-BY-4.0
+---
+
+The system prompt is the single most important piece of configuration in your chatbot. It determines the bot's personality, capabilities, boundaries, and behaviour in edge cases. A well-crafted prompt handles the easy cases and the hard ones — off-topic questions, ambiguous input, hostile users, requests for information the bot doesn't have. A poorly crafted prompt produces inconsistent behaviour that erodes user trust.
+
+Production prompt engineering is systematic. You design prompts with explicit structure, test them against a suite of edge cases, version them like code, and deploy changes through A/B tests. Small wording changes can have significant behavioural impact, so every revision should be deliberate and measured.
+
+## System Prompt Design Patterns
+
+Three patterns cover the majority of production chatbot prompts.
+
+**Pattern 1: Role + Task + Constraints** is the most common. It defines who the bot is, what it can do, what it cannot do, and how it should behave:
+
+```python
+system_prompt = """You are an expert customer support agent for TechCorp,
+a B2B SaaS company specializing in project management software.
+
+Your capabilities:
+- Answer questions about product features and pricing
+- Troubleshoot common technical issues
+- Guide users through setup and configuration
+- Access product documentation via search
+
+Your constraints:
+- Never make up information about features that don't exist
+- Never share sensitive user data
+- Cannot process refunds (escalate to billing team)
+- Cannot modify user accounts directly
+
+Guidelines:
+1. Always be professional, patient, and empathetic
+2. Ask clarifying questions before providing solutions
+3. Cite documentation sources when available
+4. If unsure, say so and offer to escalate
+5. Keep responses concise (under 150 words unless detailed explanation needed)
+
+When troubleshooting:
+1. Acknowledge the issue
+2. Ask diagnostic questions
+3. Provide step-by-step solutions
+4. Verify resolution
+"""
+```
+
+The explicit constraints are critical. Without "never make up information about features that don't exist," the bot will confidently describe non-existent features. Without "cannot process refunds," it might promise a refund it can't deliver. Every constraint prevents a class of failures you've either observed or can anticipate.
+
+**Pattern 2: Few-Shot Examples** teaches the model through demonstration rather than description. This is more effective for subtle behavioural nuances that are hard to specify in words:
+
+```
+You are a code review assistant.
+
+Examples:
+
+User: "Is this code good? x = x + 1"
+Assistant: "This code works but can be simplified to `x += 1` which is more Pythonic."
+
+User: "Should I use a list or set here?"
+Assistant: "It depends on your use case:
+- Use a list if you need ordered elements or duplicates
+- Use a set if you need fast lookups and unique elements only
+What's your specific requirement?"
+```
+
+The examples demonstrate the desired tone, level of detail, and conversational style more precisely than any description could.
+
+**Pattern 3: Chain-of-Thought** improves reasoning quality for complex tasks by instructing the model to think step-by-step before answering:
+
+```
+You are a math tutor. For each problem:
+
+1. First, think through the problem step-by-step
+2. Show your reasoning process
+3. Then provide the final answer
+
+Example:
+Problem: "What is 15% of 80?"
+
+Thinking:
+- 15% means 15/100 = 0.15
+- We multiply: 0.15 x 80
+- 0.15 x 80 = 12
+
+Answer: 15% of 80 is 12.
+```
+
+This pattern is particularly useful for RAG chatbots that need to synthesise information from multiple retrieved documents.
+
+## Handling Edge Cases
+
+Real users do not behave like test scripts. They ask off-topic questions, provide vague input, send hostile messages, ask multiple questions at once, and test the boundaries of the system. Your prompt must handle all of these gracefully.
+
+**Out-of-scope questions** are the most common edge case. A customer support bot will be asked about the weather, sports, and politics. The prompt should redirect politely: "I'm a TechCorp support assistant and can't check weather information. I can help with questions about our project management software, troubleshooting, or account issues. What can I assist you with today?"
+
+**Ambiguous queries** like "it's not working" need clarification rather than guessing. The prompt should instruct the bot to ask diagnostic questions: "What specifically isn't working? What were you trying to do? What error message did you see?"
+
+**Multi-intent queries** like "What's your pricing and can you reset my password?" should be addressed systematically, handling each question separately.
+
+**Hallucination prevention** is especially important for RAG chatbots. The prompt should include an explicit instruction: "CRITICAL: Only provide information based on the provided context documents. If you don't know something or the context doesn't contain the answer, explicitly say 'I don't have that information' rather than guessing."
+
+You can build these handlers programmatically into your prompt:
+
+```python
+def build_robust_prompt(base_prompt, edge_case_handlers):
+    """Build prompt with edge case handling."""
+    prompt = base_prompt + "\n\nEdge Case Handling:\n"
+
+    for case, handler in edge_case_handlers.items():
+        prompt += f"\n- {case}: {handler}"
+
+    return prompt
+
+edge_cases = {
+    "out_of_scope": "Politely redirect to in-scope topics",
+    "ambiguous": "Ask 2-3 clarifying questions",
+    "multiple_questions": "Address each question separately",
+    "hostile_user": "Remain professional, offer to escalate if needed"
+}
+
+system_prompt = build_robust_prompt(base_prompt, edge_cases)
+```
+
+## Prompt Versioning and Testing
+
+Prompts should be treated like code: stored in version-controlled files, tested against a suite of cases, and deployed through a controlled rollout process.
+
+```python
+SYSTEM_PROMPTS = {
+    "v1.0": """You are a helpful assistant.""",
+    "v1.1": """You are a helpful assistant who provides clear, concise answers.""",
+    "v2.0": """You are an expert customer support agent...[detailed prompt]""",
+    "v2.1": """You are an expert customer support agent...[with edge case handling]"""
+}
+
+CURRENT_VERSION = "v2.1"
+
+def get_system_prompt(version=None):
+    """Get system prompt by version."""
+    version = version or CURRENT_VERSION
+    return SYSTEM_PROMPTS[version]
+```
+
+A prompt testing framework validates expected behaviour across edge cases before deployment:
+
+```python
+class PromptTester:
+    def __init__(self, test_cases):
+        self.test_cases = test_cases
+
+    def test_prompt(self, system_prompt):
+        """Test a prompt against predefined cases."""
+        results = []
+
+        for case in self.test_cases:
+            response = llm.generate(
+                system_prompt=system_prompt,
+                user_message=case["input"]
+            )
+
+            passed = case["validator"](response)
+
+            results.append({
+                "input": case["input"],
+                "response": response,
+                "expected": case["description"],
+                "passed": passed
+            })
+
+        pass_rate = sum(r["passed"] for r in results) / len(results)
+        return {"pass_rate": pass_rate, "results": results}
+
+test_cases = [
+    {
+        "input": "What's the weather?",
+        "description": "Should redirect out-of-scope questions",
+        "validator": lambda r: "can't help with weather" in r.lower()
+    },
+    {
+        "input": "How do I reset password?",
+        "description": "Should provide relevant answer",
+        "validator": lambda r: "password" in r.lower() and len(r) > 50
+    },
+    {
+        "input": "asdfghjkl",
+        "description": "Should handle gibberish gracefully",
+        "validator": lambda r: "don't understand" in r.lower() or "clarify" in r.lower()
+    }
+]
+
+tester = PromptTester(test_cases)
+v2_results = tester.test_prompt(get_system_prompt("v2.0"))
+v2_1_results = tester.test_prompt(get_system_prompt("v2.1"))
+
+print(f"v2.0 pass rate: {v2_results['pass_rate']:.0%}")
+print(f"v2.1 pass rate: {v2_1_results['pass_rate']:.0%}")
+```
+
+The workflow is: write a new prompt version, run it through the test suite, compare pass rates against the current version, A/B test in production with a small percentage of traffic (10–20%), and roll out to 100% if metrics improve. If a deployed prompt causes issues, roll back to the previous version immediately — this is why versioning matters.

--- a/technology_and_tooling/chatbot_development/m7-01-production-prompt-engineering.md
+++ b/technology_and_tooling/chatbot_development/m7-01-production-prompt-engineering.md
@@ -11,6 +11,7 @@ attribution:
   - citation: >
       Oxford AI Competency Centre (2026). Chatbot Development Course.
     url: https://github.com/OxfordCompetencyCenters/aicc_chatbot_modules
+    image: https://github.com/OxfordCompetencyCenters.png
     license: CC-BY-4.0
 ---
 

--- a/technology_and_tooling/chatbot_development/m7-02-safety-and-content-moderation.md
+++ b/technology_and_tooling/chatbot_development/m7-02-safety-and-content-moderation.md
@@ -1,0 +1,230 @@
+---
+name: Safety and Content Moderation
+dependsOn:
+  - technology_and_tooling.chatbot_development.m7-01-production-prompt-engineering
+tags: [chatbots, safety, moderation, pii, privacy, optional]
+learningOutcomes:
+  - Implement automated content moderation using the OpenAI Moderation API.
+  - Detect and redact personally identifiable information (PII) from chatbot interactions.
+  - Build GDPR-compliant data handling for user conversations and profiles.
+attribution:
+  - citation: >
+      Oxford AI Competency Centre (2026). Chatbot Development Course.
+    url: https://github.com/OxfordCompetencyCenters/aicc_chatbot_modules
+    license: CC-BY-4.0
+---
+
+A production chatbot must be safe. Users will send inappropriate content — sometimes deliberately, sometimes accidentally. The bot itself can generate harmful output if prompted in certain ways or if the underlying model produces unexpected responses. And users will share sensitive personal information (email addresses, phone numbers, credit card details) that needs to be handled carefully. Content moderation, PII protection, and privacy compliance are not optional features. They are requirements.
+
+## Automated Content Moderation
+
+OpenAI provides a free Moderation API that checks text for categories of harmful content: hate speech, harassment, self-harm, sexual content, and violence. The API is fast (roughly 100ms per call) and should be applied to both user inputs and bot outputs — checking inputs prevents processing harmful requests, and checking outputs catches cases where the model generates something inappropriate despite safe input.
+
+```python
+import openai
+
+class ContentModerator:
+    CATEGORIES = [
+        "hate", "hate/threatening",
+        "harassment", "harassment/threatening",
+        "self-harm", "self-harm/intent", "self-harm/instructions",
+        "sexual", "sexual/minors",
+        "violence", "violence/graphic"
+    ]
+
+    def __init__(self, threshold=0.5):
+        self.threshold = threshold
+
+    def check_content(self, text):
+        """Check if content violates policies."""
+        response = openai.Moderation.create(input=text)
+        result = response["results"][0]
+
+        violations = []
+        for category, flagged in result["categories"].items():
+            if flagged:
+                score = result["category_scores"][category]
+                if score > self.threshold:
+                    violations.append({
+                        "category": category,
+                        "score": score
+                    })
+
+        return {
+            "flagged": result["flagged"],
+            "violations": violations,
+            "safe": not result["flagged"]
+        }
+```
+
+Integrating the moderator into the chat endpoint creates a defence-in-depth approach — check the input, then check the output:
+
+```python
+moderator = ContentModerator()
+
+@app.post("/chat")
+async def chat(request: ChatRequest):
+    # Check user input
+    user_check = moderator.check_content(request.message)
+
+    if not user_check["safe"]:
+        logger.warning("unsafe_user_input", extra={
+            "user_id": request.user_id,
+            "violations": user_check["violations"]
+        })
+        return {
+            "response": "I can't process that request. Please keep our conversation appropriate.",
+            "flagged": True
+        }
+
+    # Generate response
+    response = llm.generate(...)
+
+    # Check bot output
+    bot_check = moderator.check_content(response)
+
+    if not bot_check["safe"]:
+        logger.error("unsafe_bot_output", extra={
+            "user_id": request.user_id,
+            "violations": bot_check["violations"],
+            "prompt": request.message
+        })
+        return {
+            "response": "I apologize, I can't provide that information. How else can I help?",
+            "flagged": True
+        }
+
+    return {"response": response, "flagged": False}
+```
+
+Beyond the general-purpose moderation API, most applications need custom moderation rules specific to their domain. A corporate chatbot might block mentions of competitors. A financial services bot might flag investment advice. These rules use pattern matching:
+
+```python
+import re
+
+class CustomModerator:
+    def __init__(self):
+        self.blocked_patterns = [
+            r'\b(competitor_name_1|competitor_name_2)\b',
+            r'\b(confidential|internal_only)\b',
+        ]
+
+        self.pii_patterns = {
+            "email": r'\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,}\b',
+            "ssn": r'\b\d{3}-\d{2}-\d{4}\b',
+            "credit_card": r'\b\d{4}[- ]?\d{4}[- ]?\d{4}[- ]?\d{4}\b'
+        }
+
+    def check_custom_rules(self, text):
+        """Check custom moderation rules."""
+        violations = []
+
+        for pattern in self.blocked_patterns:
+            if re.search(pattern, text, re.IGNORECASE):
+                violations.append({"type": "blocklist", "pattern": pattern})
+
+        for pii_type, pattern in self.pii_patterns.items():
+            if re.search(pattern, text):
+                violations.append({"type": "pii", "pii_type": pii_type})
+
+        return {"safe": len(violations) == 0, "violations": violations}
+```
+
+Log all moderation violations for analysis. Patterns in the violations data can reveal attack attempts, gaps in your moderation rules, or topics that need better handling.
+
+## PII Detection and Redaction
+
+Users frequently share sensitive personal information in chatbot conversations — email addresses, phone numbers, credit card numbers, social security numbers. This data needs to be detected and either redacted before processing or handled with special care.
+
+Microsoft's Presidio library provides production-grade PII detection:
+
+```python
+from presidio_analyzer import AnalyzerEngine
+from presidio_anonymizer import AnonymizerEngine
+
+class PIIHandler:
+    def __init__(self):
+        self.analyzer = AnalyzerEngine()
+        self.anonymizer = AnonymizerEngine()
+
+    def detect_pii(self, text):
+        """Detect PII in text."""
+        results = self.analyzer.analyze(
+            text=text,
+            language="en",
+            entities=[
+                "PHONE_NUMBER", "EMAIL_ADDRESS",
+                "CREDIT_CARD", "IBAN_CODE",
+                "US_SSN", "US_PASSPORT",
+                "PERSON", "LOCATION"
+            ]
+        )
+        return results
+
+    def redact_pii(self, text):
+        """Redact PII from text, replacing with placeholders."""
+        results = self.detect_pii(text)
+        anonymized = self.anonymizer.anonymize(text=text, analyzer_results=results)
+        return anonymized.text
+
+    def mask_sensitive_data(self, text):
+        """Mask common sensitive patterns using regex."""
+        text = re.sub(
+            r'\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,}\b',
+            '[EMAIL]', text)
+        text = re.sub(r'\b\d{3}[-.]?\d{3}[-.]?\d{4}\b', '[PHONE]', text)
+        text = re.sub(r'\b\d{4}[- ]?\d{4}[- ]?\d{4}[- ]?\d{4}\b', '[CREDIT_CARD]', text)
+        text = re.sub(r'\b\d{3}-\d{2}-\d{4}\b', '[SSN]', text)
+        return text
+```
+
+When PII is detected in user input, you have two options: reject the request and ask the user not to share sensitive information, or redact the PII and continue processing with the sanitised text. The choice depends on your application. A customer support bot might redact and continue (the user might include their email naturally). A general chatbot might warn the user.
+
+Critically, PII must be masked before logging. You do not want credit card numbers appearing in your log aggregation system:
+
+```python
+pii_handler = PIIHandler()
+
+@app.post("/chat")
+async def chat(request: ChatRequest):
+    pii_detected = pii_handler.detect_pii(request.message)
+
+    if pii_detected:
+        logger.warning("pii_detected_in_input", extra={
+            "user_id": request.user_id,
+            "pii_types": [result.entity_type for result in pii_detected]
+        })
+
+    # Mask before logging
+    safe_log_message = pii_handler.mask_sensitive_data(request.message)
+    logger.info("chat_request", extra={"message": safe_log_message})
+
+    return response
+```
+
+## GDPR Compliance
+
+If your chatbot serves users in the European Union, GDPR compliance is a legal requirement. Two key rights that affect chatbot systems are the right to access (users can request all data you hold about them) and the right to erasure (users can request deletion of all their data):
+
+```python
+class GDPRCompliance:
+    def __init__(self, db):
+        self.db = db
+
+    def user_data_export(self, user_id):
+        """Export all data for a user (right to access)."""
+        return {
+            "conversations": self.db.get_user_conversations(user_id),
+            "profile": self.db.get_user_profile(user_id),
+            "logs": self.db.get_user_logs(user_id)
+        }
+
+    def delete_user_data(self, user_id):
+        """Delete all user data (right to be forgotten)."""
+        self.db.delete_user_conversations(user_id)
+        self.db.delete_user_profile(user_id)
+        self.db.anonymize_user_logs(user_id)
+        logger.info("user_data_deleted", extra={"user_id": user_id})
+```
+
+Implement these as API endpoints that users (or your support team) can invoke. For the deletion endpoint, note that logs are anonymised rather than deleted — you may need to retain anonymised logs for operational purposes, but they must not be linkable back to the individual user. Also define and communicate a data retention policy: how long do you store conversations? When are they automatically purged? For healthcare applications (HIPAA compliance), the requirements are even stricter and may require a Business Associate Agreement with your cloud provider.

--- a/technology_and_tooling/chatbot_development/m7-02-safety-and-content-moderation.md
+++ b/technology_and_tooling/chatbot_development/m7-02-safety-and-content-moderation.md
@@ -11,6 +11,7 @@ attribution:
   - citation: >
       Oxford AI Competency Centre (2026). Chatbot Development Course.
     url: https://github.com/OxfordCompetencyCenters/aicc_chatbot_modules
+    image: https://github.com/OxfordCompetencyCenters.png
     license: CC-BY-4.0
 ---
 

--- a/technology_and_tooling/chatbot_development/m7-03-cost-optimisation.md
+++ b/technology_and_tooling/chatbot_development/m7-03-cost-optimisation.md
@@ -1,7 +1,7 @@
 ---
 name: Cost Optimisation
 dependsOn:
-  - technology_and_tooling.chatbot_development.m7-02-safety-and-content-moderation
+  - technology_and_tooling.chatbot_development.m7-01-production-prompt-engineering
 tags: [chatbots, cost-optimisation, token-management, model-routing, optional]
 learningOutcomes:
   - Apply token reduction strategies including prompt compression and selective context.

--- a/technology_and_tooling/chatbot_development/m7-03-cost-optimisation.md
+++ b/technology_and_tooling/chatbot_development/m7-03-cost-optimisation.md
@@ -11,6 +11,7 @@ attribution:
   - citation: >
       Oxford AI Competency Centre (2026). Chatbot Development Course.
     url: https://github.com/OxfordCompetencyCenters/aicc_chatbot_modules
+    image: https://github.com/OxfordCompetencyCenters.png
     license: CC-BY-4.0
 ---
 

--- a/technology_and_tooling/chatbot_development/m7-03-cost-optimisation.md
+++ b/technology_and_tooling/chatbot_development/m7-03-cost-optimisation.md
@@ -1,0 +1,186 @@
+---
+name: Cost Optimisation
+dependsOn:
+  - technology_and_tooling.chatbot_development.m7-02-safety-and-content-moderation
+tags: [chatbots, cost-optimisation, token-management, model-routing, optional]
+learningOutcomes:
+  - Apply token reduction strategies including prompt compression and selective context.
+  - Implement a smart model router that selects cheaper models for simpler queries.
+  - Estimate and measure cost savings from optimisation techniques.
+attribution:
+  - citation: >
+      Oxford AI Competency Centre (2026). Chatbot Development Course.
+    url: https://github.com/OxfordCompetencyCenters/aicc_chatbot_modules
+    license: CC-BY-4.0
+---
+
+LLM API costs are the dominant operational expense for most chatbot systems, and they scale linearly with usage. Every token in every request costs money — both the tokens you send (the prompt, context, and conversation history) and the tokens the model generates (the response). At 10,000 requests per day, even small per-request optimisations compound into significant monthly savings. Cost optimisation is not about cutting corners on quality; it's about eliminating waste so your budget is spent on tokens that actually improve the user experience.
+
+## Token Reduction Strategies
+
+**Prompt compression** is the easiest win. Many system prompts contain redundant or verbose phrasing that can be tightened without changing behaviour:
+
+```python
+# Verbose: ~150 tokens
+prompt = """
+You are a helpful customer support assistant. You should always
+be polite and professional. When answering questions, make sure
+to be clear and concise. If you don't know something, say so.
+Always try to help the customer as best as you can.
+"""
+
+# Concise: ~60 tokens (60% reduction)
+prompt = """
+You are a polite, professional customer support assistant.
+Be clear and concise. If unsure, admit it.
+"""
+```
+
+Both prompts produce essentially the same behaviour, but the concise version saves 90 tokens per request. At 10,000 requests per day with GPT-3.5-turbo, that's 900,000 fewer input tokens per day — roughly $0.45/day or $13.50/month just from tightening the system prompt.
+
+**Selective context inclusion** prevents sending irrelevant documents to the LLM. In a RAG system, not all retrieved documents are equally relevant. Rather than sending a fixed number of documents, rank them by relevance and include only those that fit within a token budget:
+
+```python
+def build_context_smartly(query, all_documents, max_tokens=1500):
+    """Include only the most relevant context within a token budget."""
+    ranked_docs = rank_by_relevance(query, all_documents)
+
+    context = []
+    token_count = 0
+
+    for doc in ranked_docs:
+        doc_tokens = count_tokens(doc)
+        if token_count + doc_tokens < max_tokens:
+            context.append(doc)
+            token_count += doc_tokens
+        else:
+            break
+
+    return context
+```
+
+**Response length limits** prevent the model from generating unnecessarily long responses. Set `max_tokens` on the API call and reinforce it in the prompt:
+
+```python
+response = openai.ChatCompletion.create(
+    model="gpt-3.5-turbo",
+    messages=messages,
+    max_tokens=150
+)
+
+# Or via prompt instruction
+system_prompt = """...[your prompt]...
+
+Keep responses under 100 words unless a detailed explanation is needed.
+"""
+```
+
+**Context summarisation** (covered in Module 4) replaces full conversation history with compressed summaries, reducing the tokens sent on each subsequent turn from thousands to hundreds.
+
+## Smart Model Routing
+
+Not every query needs the most expensive model. Simple factual questions, greetings, and straightforward lookups are handled well by GPT-3.5-turbo. Complex reasoning, nuanced analysis, and code generation benefit from GPT-4. A smart router classifies query complexity and routes to the appropriate model:
+
+```python
+class SmartModelRouter:
+    def __init__(self):
+        self.models = {
+            "simple": {"name": "gpt-3.5-turbo", "cost": 0.002},
+            "complex": {"name": "gpt-4", "cost": 0.06}
+        }
+
+    def classify_query_complexity(self, query):
+        """Classify a query as simple or complex."""
+        complexity_indicators = {
+            "simple": [
+                "what is", "who is", "when",
+                "list", "define", "meaning"
+            ],
+            "complex": [
+                "analyze", "compare", "why", "how does",
+                "explain the difference", "design", "create"
+            ]
+        }
+
+        query_lower = query.lower()
+
+        simple_count = sum(1 for ind in complexity_indicators["simple"]
+                          if ind in query_lower)
+        complex_count = sum(1 for ind in complexity_indicators["complex"]
+                           if ind in query_lower)
+
+        if len(query.split()) > 30:
+            complex_count += 1
+
+        return "complex" if complex_count > simple_count else "simple"
+
+    def route_request(self, query):
+        """Route to the appropriate model."""
+        complexity = self.classify_query_complexity(query)
+        model = self.models[complexity]
+
+        logger.info("model_routing", extra={
+            "complexity": complexity,
+            "model": model["name"],
+            "query_length": len(query)
+        })
+
+        return model["name"]
+```
+
+The cost impact is dramatic. If 80% of queries are simple and routed to GPT-3.5, and 20% are complex and routed to GPT-4, the daily cost at 10,000 requests drops from $600 (all GPT-4) to roughly $136 — a 77% reduction. Monitor the routing accuracy over time: if simple queries routed to GPT-3.5 frequently produce poor responses, adjust the classification thresholds.
+
+## Estimating Savings
+
+Before implementing optimisations, estimate their impact to prioritise your effort:
+
+```python
+class TokenOptimizer:
+    def estimate_savings(self, optimizations):
+        """Estimate cost savings from a set of optimisations."""
+        baseline = {
+            "avg_prompt_tokens": 2000,
+            "avg_completion_tokens": 400,
+            "requests_per_day": 10000
+        }
+
+        baseline_cost_per_request = (
+            (baseline["avg_prompt_tokens"] / 1000) * 0.0005 +
+            (baseline["avg_completion_tokens"] / 1000) * 0.0015
+        )
+        baseline_daily_cost = baseline_cost_per_request * baseline["requests_per_day"]
+
+        optimized = baseline.copy()
+        for opt in optimizations:
+            if opt["type"] == "prompt_compression":
+                optimized["avg_prompt_tokens"] *= (1 - opt["reduction"])
+            elif opt["type"] == "response_limit":
+                optimized["avg_completion_tokens"] *= (1 - opt["reduction"])
+            elif opt["type"] == "caching":
+                optimized["requests_per_day"] *= (1 - opt["hit_rate"])
+
+        optimized_cost_per_request = (
+            (optimized["avg_prompt_tokens"] / 1000) * 0.0005 +
+            (optimized["avg_completion_tokens"] / 1000) * 0.0015
+        )
+        optimized_daily_cost = optimized_cost_per_request * optimized["requests_per_day"]
+
+        return {
+            "baseline_daily": baseline_daily_cost,
+            "optimized_daily": optimized_daily_cost,
+            "daily_savings": baseline_daily_cost - optimized_daily_cost,
+            "monthly_savings": (baseline_daily_cost - optimized_daily_cost) * 30,
+            "savings_percentage": (1 - optimized_daily_cost / baseline_daily_cost) * 100
+        }
+
+optimizer = TokenOptimizer()
+savings = optimizer.estimate_savings([
+    {"type": "prompt_compression", "reduction": 0.30},
+    {"type": "response_limit", "reduction": 0.20},
+    {"type": "caching", "hit_rate": 0.40}
+])
+
+print(f"Monthly savings: ${savings['monthly_savings']:.2f} ({savings['savings_percentage']:.1f}%)")
+```
+
+Combining 30% prompt compression, 20% shorter responses, and a 40% cache hit rate can reduce costs by 60% or more. At 10,000 requests per day, this translates to over $1,000 per month in savings. Use the cost tracking system from Module 6 to verify actual savings after implementation and identify further opportunities.

--- a/technology_and_tooling/chatbot_development/m7-04-scaling-strategies.md
+++ b/technology_and_tooling/chatbot_development/m7-04-scaling-strategies.md
@@ -1,7 +1,7 @@
 ---
 name: Scaling Strategies
 dependsOn:
-  - technology_and_tooling.chatbot_development.m7-03-cost-optimisation
+  - technology_and_tooling.chatbot_development.m7-01-production-prompt-engineering
 tags: [chatbots, scaling, redis, load-balancing, rate-limiting, optional]
 learningOutcomes:
   - Design stateless chatbot services that support horizontal scaling.

--- a/technology_and_tooling/chatbot_development/m7-04-scaling-strategies.md
+++ b/technology_and_tooling/chatbot_development/m7-04-scaling-strategies.md
@@ -1,0 +1,197 @@
+---
+name: Scaling Strategies
+dependsOn:
+  - technology_and_tooling.chatbot_development.m7-03-cost-optimisation
+tags: [chatbots, scaling, redis, load-balancing, rate-limiting, optional]
+learningOutcomes:
+  - Design stateless chatbot services that support horizontal scaling.
+  - Externalise conversation state to Redis for distributed deployments.
+  - Implement rate limiting and backpressure to protect the system under load.
+attribution:
+  - citation: >
+      Oxford AI Competency Centre (2026). Chatbot Development Course.
+    url: https://github.com/OxfordCompetencyCenters/aicc_chatbot_modules
+    license: CC-BY-4.0
+---
+
+As your chatbot gains users, a single server instance will eventually become a bottleneck. LLM API calls take seconds, and each request ties up server resources while waiting for the response. With 100 concurrent users and 3-second response times, your server is processing roughly 33 requests per second — manageable for a single instance. At 1,000 concurrent users, you need multiple server instances sharing the load. Horizontal scaling — adding more server instances behind a load balancer — is the standard approach, but it requires your application to be stateless.
+
+## Stateless Design
+
+The challenge with horizontal scaling is state. If Server A holds User 1's conversation history in memory, and the load balancer routes User 1's next request to Server B, the conversation context is lost. Server B doesn't know what was discussed on Server A.
+
+The solution is to externalise all state to a shared data store. Redis is the standard choice for conversation state because it's fast (sub-millisecond reads and writes), supports expiration (conversations can automatically expire after inactivity), and is designed for this exact use case.
+
+```python
+import redis
+import json
+from datetime import timedelta
+
+class DistributedMemory:
+    def __init__(self):
+        self.redis = redis.Redis(
+            host='redis-server',
+            port=6379,
+            decode_responses=True
+        )
+
+    def store_conversation(self, session_id, messages):
+        """Store conversation in Redis with 24-hour expiration."""
+        key = f"conversation:{session_id}"
+        self.redis.setex(
+            key,
+            timedelta(hours=24),
+            json.dumps(messages)
+        )
+
+    def get_conversation(self, session_id):
+        """Retrieve conversation from Redis."""
+        key = f"conversation:{session_id}"
+        data = self.redis.get(key)
+        if data:
+            return json.loads(data)
+        return []
+
+    def append_message(self, session_id, role, content):
+        """Append a message to a conversation."""
+        messages = self.get_conversation(session_id)
+        messages.append({"role": role, "content": content})
+        self.store_conversation(session_id, messages)
+```
+
+With externalised state, the chat endpoint becomes truly stateless — any server instance can handle any request:
+
+```python
+memory = DistributedMemory()
+
+@app.post("/chat")
+async def chat(request: ChatRequest):
+    messages = memory.get_conversation(request.session_id)
+    messages.append({"role": "user", "content": request.message})
+
+    response = llm.generate(messages=messages)
+
+    messages.append({"role": "assistant", "content": response})
+    memory.store_conversation(request.session_id, messages)
+
+    return {"response": response}
+```
+
+## Load Balancing
+
+With stateless servers, you can run multiple instances behind a load balancer. NGINX is a common choice:
+
+```yaml
+# docker-compose.yml
+services:
+  nginx:
+    image: nginx
+    ports:
+      - "80:80"
+    volumes:
+      - ./nginx.conf:/etc/nginx/nginx.conf
+
+  backend1:
+    build: ./backend
+    environment:
+      - REDIS_URL=redis://redis:6379
+
+  backend2:
+    build: ./backend
+    environment:
+      - REDIS_URL=redis://redis:6379
+
+  backend3:
+    build: ./backend
+    environment:
+      - REDIS_URL=redis://redis:6379
+
+  redis:
+    image: redis:7-alpine
+```
+
+```nginx
+upstream backend {
+    least_conn;
+    server backend1:8000;
+    server backend2:8000;
+    server backend3:8000;
+}
+
+server {
+    listen 80;
+
+    location / {
+        proxy_pass http://backend;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+    }
+}
+```
+
+The `least_conn` directive routes each request to the server with the fewest active connections, distributing load evenly. Scaling is now a matter of adding more backend containers. All instances connect to the same Redis instance, so they share conversation state seamlessly.
+
+For very high scale, Redis itself can become a bottleneck. Redis Cluster distributes data across multiple Redis nodes. Alternatively, PostgreSQL with connection pooling (using PgBouncer) provides a more durable storage option at the cost of slightly higher latency.
+
+## Rate Limiting and Backpressure
+
+Without rate limiting, a single user (or an attacker) can consume all your server capacity and LLM API budget. Rate limiting caps the number of requests per user per time window. The `slowapi` library integrates cleanly with FastAPI:
+
+```python
+from slowapi import Limiter, _rate_limit_exceeded_handler
+from slowapi.util import get_remote_address
+from slowapi.errors import RateLimitExceeded
+
+limiter = Limiter(key_func=get_remote_address)
+app.state.limiter = limiter
+app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
+
+@app.post("/chat")
+@limiter.limit("10/minute")
+async def chat(request: Request, chat_request: ChatRequest):
+    return response
+```
+
+This limits each IP address to 10 requests per minute. For authenticated users, you can rate limit per user ID instead, allowing higher limits for paying customers and stricter limits for free-tier users.
+
+Backpressure handles traffic spikes by limiting the number of concurrent LLM calls. Without backpressure, a traffic spike sends hundreds of simultaneous requests to the LLM API, all of which time out or fail. With backpressure, a semaphore limits concurrent processing, and excess requests are queued:
+
+```python
+import asyncio
+from asyncio import Queue
+
+class RequestQueue:
+    def __init__(self, max_concurrent=10):
+        self.queue = Queue()
+        self.semaphore = asyncio.Semaphore(max_concurrent)
+
+    async def process_request(self, request):
+        """Process a request with concurrency limit."""
+        async with self.semaphore:
+            response = await generate_response(request)
+            return response
+
+    async def enqueue(self, request):
+        """Add a request to the queue."""
+        await self.queue.put(request)
+
+    async def worker(self):
+        """Worker that processes queued requests."""
+        while True:
+            request = await self.queue.get()
+            try:
+                response = await self.process_request(request)
+            except Exception as e:
+                logger.error(f"Request failed: {e}")
+            finally:
+                self.queue.task_done()
+
+request_queue = RequestQueue(max_concurrent=10)
+
+@app.on_event("startup")
+async def startup():
+    for _ in range(5):
+        asyncio.create_task(request_queue.worker())
+```
+
+The semaphore ensures that at most 10 LLM calls are in flight at any time. Additional requests wait in the queue rather than overwhelming the system. For user-facing applications where waiting in a queue is acceptable, this provides graceful degradation under load. For applications where latency is critical, return a job ID immediately and let the client poll for the result — this decouples request submission from response delivery.

--- a/technology_and_tooling/chatbot_development/m7-04-scaling-strategies.md
+++ b/technology_and_tooling/chatbot_development/m7-04-scaling-strategies.md
@@ -11,6 +11,7 @@ attribution:
   - citation: >
       Oxford AI Competency Centre (2026). Chatbot Development Course.
     url: https://github.com/OxfordCompetencyCenters/aicc_chatbot_modules
+    image: https://github.com/OxfordCompetencyCenters.png
     license: CC-BY-4.0
 ---
 

--- a/technology_and_tooling/chatbot_development/m7-05-alternative-llm-providers.md
+++ b/technology_and_tooling/chatbot_development/m7-05-alternative-llm-providers.md
@@ -1,0 +1,186 @@
+---
+name: Alternative LLM Providers
+dependsOn:
+  - technology_and_tooling.chatbot_development.m7-04-scaling-strategies
+tags: [chatbots, llm-providers, open-source, production-checklist, optional]
+learningOutcomes:
+  - Compare LLM providers across cost, quality, speed, and context length.
+  - Implement a multi-provider architecture with automatic fallback.
+  - Apply a production readiness checklist to prepare a chatbot for deployment.
+attribution:
+  - citation: >
+      Oxford AI Competency Centre (2026). Chatbot Development Course.
+    url: https://github.com/OxfordCompetencyCenters/aicc_chatbot_modules
+    license: CC-BY-4.0
+---
+
+Throughout this course, the examples have used OpenAI's models. But OpenAI is not the only option, and it's not always the best one. Depending on your requirements — cost, quality, context length, data privacy, regulatory constraints — other providers may be a better fit. A production system should also be resilient to provider outages, which means supporting multiple providers with automatic fallback.
+
+## Provider Comparison
+
+The major LLM providers each have distinct strengths:
+
+**OpenAI** offers GPT-4 (highest overall quality, expensive) and GPT-3.5-turbo (fast, cheap, good for most tasks). OpenAI has the most mature API ecosystem and the broadest developer adoption. It's the safe default choice for most applications.
+
+**Anthropic** offers the Claude model family. Claude's strengths are very long context windows (up to 200K tokens), strong reasoning capabilities, and a generally lower hallucination rate. Claude is well-suited for tasks that require processing large amounts of text or careful analytical reasoning.
+
+**Google** offers Gemini models with good quality and native multimodal capabilities (text, images, video). Gemini integrates well with the Google Cloud ecosystem.
+
+**Open-source models** (Llama, Mistral, and others) offer full control over the model and infrastructure. There are no per-token costs — you pay only for the compute infrastructure. Data never leaves your servers, which satisfies strict privacy and regulatory requirements. The trade-off is lower quality than the best commercial models (open-source models at the 70B parameter scale are roughly comparable to GPT-3.5), infrastructure complexity, and the need for GPU hardware.
+
+The right choice depends on your use case. For most applications starting out, OpenAI or Anthropic commercial APIs are the pragmatic choice. At very high volume (millions of tokens per day) or with strict data residency requirements, self-hosted open-source models become cost-effective.
+
+## Multi-Provider Architecture
+
+A multi-provider strategy provides both flexibility and resilience. If your primary provider experiences an outage — which happens to every cloud service — your chatbot continues operating by falling back to an alternative:
+
+```python
+class MultiProviderLLM:
+    def __init__(self):
+        self.providers = {
+            "openai": OpenAIProvider(),
+            "anthropic": AnthropicProvider(),
+            "local": LocalLlamaProvider()
+        }
+
+    def generate(self, prompt, provider="openai", fallback=True):
+        """Generate with the specified provider, falling back on failure."""
+        try:
+            return self.providers[provider].generate(prompt)
+        except Exception as e:
+            logger.error(f"{provider} failed: {e}")
+
+            if fallback:
+                fallback_provider = "anthropic" if provider == "openai" else "openai"
+                logger.info(f"Falling back to {fallback_provider}")
+                return self.providers[fallback_provider].generate(prompt)
+
+            raise
+
+llm = MultiProviderLLM()
+response = llm.generate(prompt, provider="openai", fallback=True)
+```
+
+You can also combine the multi-provider architecture with the smart model router from the cost optimisation section: route simple queries to a cheap, fast model (or even a self-hosted open-source model), and route complex queries to a high-quality commercial model.
+
+## Self-Hosted LLMs
+
+For organisations where data privacy is paramount or where per-token costs at scale are prohibitive, self-hosting an open-source LLM is an option. vLLM is the standard serving framework — it optimises GPU memory usage and throughput:
+
+```bash
+pip install vllm
+
+python -m vllm.entrypoints.api_server \
+    --model meta-llama/Llama-2-7b-chat-hf \
+    --host 0.0.0.0 \
+    --port 8000
+```
+
+```python
+import requests
+
+response = requests.post("http://localhost:8000/generate", json={
+    "prompt": "What is Python?",
+    "max_tokens": 100
+})
+print(response.json()["text"])
+```
+
+Self-hosting requires GPU infrastructure. An AWS p3.8xlarge instance with 4 V100 GPUs costs roughly $12/hour ($8,640/month). The break-even point compared to API pricing depends on your volume: at approximately 50 million tokens per month, self-hosting a model in the GPT-3.5 quality tier becomes cheaper than using the API. Below that volume, the API is more cost-effective and far simpler to operate.
+
+For production self-hosted deployments, use TensorRT-LLM or vLLM for inference optimisation, deploy on GPU instances (AWS p3/p4, GCP A100), use Kubernetes for orchestration and scaling, and monitor GPU utilisation to ensure you're getting value from the hardware.
+
+## Production Readiness Checklist
+
+Before deploying a chatbot to production, review this checklist. Each item prevents a class of failures:
+
+**Security:**
+- All secrets stored in environment variables or a secret manager
+- HTTPS enabled with valid certificates
+- Authentication implemented (JWT or similar)
+- Content moderation active on both inputs and outputs
+- PII detection and handling implemented
+- Rate limiting configured
+- Input validation on all endpoints
+
+**Reliability:**
+- Error handling and graceful degradation on all code paths
+- Health check endpoint functional
+- Retry logic with exponential backoff for external API calls
+- Timeouts configured for all network requests
+- Circuit breakers for external services
+- Multi-provider fallback (if applicable)
+
+**Observability:**
+- Structured logging with trace IDs
+- Metrics tracking for latency, cost, and error rate
+- Distributed tracing (if running microservices)
+- Alerting configured for critical metrics
+- Dashboard for real-time monitoring
+
+**Performance:**
+- Semantic caching implemented
+- Prompt optimisation completed
+- Response length limits set
+- Model routing strategy defined
+- Load testing completed
+
+**Scalability:**
+- Stateless design with externalised state
+- Horizontal scaling tested
+- Database connection pooling configured
+- Async processing for slow operations
+
+**Compliance:**
+- Data retention policy defined and implemented
+- GDPR compliance (if serving EU users)
+- Terms of service and privacy policy published
+- Audit logging for sensitive operations
+
+::::challenge{id=m7-05-ex1 title="Production Hardening"}
+
+Apply production best practices to your capstone chatbot:
+
+1. **Content moderation (15 minutes):** Integrate the OpenAI Moderation API. Check both user inputs and bot outputs. Log all violations.
+
+2. **PII handling (15 minutes):** Add PII detection using regex patterns or Presidio. Mask PII before logging. Decide whether to reject, redact, or warn when PII is detected.
+
+3. **Cost optimisation (15 minutes):** Compress your system prompt. Add selective context inclusion for RAG. Set `max_tokens` on API calls.
+
+4. **Rate limiting (10 minutes):** Add per-IP and per-user rate limits using `slowapi`.
+
+5. **Adversarial testing (20 minutes):** Test your chatbot with off-topic queries, prompt injection attempts, PII in messages, high request volume, and malformed inputs. Fix any failures.
+
+6. **Checklist review:** Walk through the production readiness checklist and check off each item.
+::::
+
+::::challenge{id=m7-05-checkpoint title="Project Checkpoint 7: Production-Ready Chatbot"}
+
+Your capstone project should now be hardened for production use.
+
+Deliverables:
+
+- Content moderation on inputs and outputs
+- PII detection and handling
+- At least three cost optimisation techniques implemented
+- Rate limiting configured
+- Adversarial test results documented
+- Production readiness checklist completed
+- Architecture documentation describing your production setup
+::::
+
+## Summary and What's Next
+
+In this module, you've applied the finishing touches that separate a prototype from a production system. You've learned to craft robust, versioned prompts that handle edge cases gracefully. You've implemented content moderation and PII protection to keep your chatbot safe and compliant. You've optimised costs through prompt compression, selective context, response limits, and smart model routing. You've designed for horizontal scale with stateless architecture, externalised state, and load balancing. You've explored alternative LLM providers and built resilience through multi-provider fallback. And you've reviewed a comprehensive production checklist to ensure nothing is missed.
+
+In Module 8, you'll bring everything together for the capstone project. You'll integrate all the components built across Modules 1–7 into a complete, production-grade chatbot system, prepare a final presentation, and document your architecture and design decisions.
+
+## Additional Resources
+
+- [Prompt Engineering Guide](https://www.promptingguide.ai/) — Comprehensive prompt engineering techniques
+- ["Building LLM Applications for Production"](https://huyenchip.com/2023/04/11/llm-engineering.html) by Chip Huyen — Practical LLM production engineering
+- [OpenAI Moderation API](https://platform.openai.com/docs/guides/moderation) — Content moderation documentation
+- [Presidio](https://microsoft.github.io/presidio/) — Microsoft's PII detection and anonymisation library
+- [slowapi](https://github.com/laurentS/slowapi) — Rate limiting for FastAPI
+- [vLLM](https://github.com/vllm-project/vllm) — High-throughput LLM serving engine
+- [Redis Documentation](https://redis.io/docs/) — Distributed state management

--- a/technology_and_tooling/chatbot_development/m7-05-alternative-llm-providers.md
+++ b/technology_and_tooling/chatbot_development/m7-05-alternative-llm-providers.md
@@ -1,7 +1,7 @@
 ---
 name: Alternative LLM Providers
 dependsOn:
-  - technology_and_tooling.chatbot_development.m7-04-scaling-strategies
+  - technology_and_tooling.chatbot_development.m7-01-production-prompt-engineering
 tags: [chatbots, llm-providers, open-source, production-checklist, optional]
 learningOutcomes:
   - Compare LLM providers across cost, quality, speed, and context length.

--- a/technology_and_tooling/chatbot_development/m7-05-alternative-llm-providers.md
+++ b/technology_and_tooling/chatbot_development/m7-05-alternative-llm-providers.md
@@ -11,6 +11,7 @@ attribution:
   - citation: >
       Oxford AI Competency Centre (2026). Chatbot Development Course.
     url: https://github.com/OxfordCompetencyCenters/aicc_chatbot_modules
+    image: https://github.com/OxfordCompetencyCenters.png
     license: CC-BY-4.0
 ---
 

--- a/technology_and_tooling/chatbot_development/m8-01-capstone-project-brief.md
+++ b/technology_and_tooling/chatbot_development/m8-01-capstone-project-brief.md
@@ -12,6 +12,7 @@ attribution:
   - citation: >
       Oxford AI Competency Centre (2026). Chatbot Development Course.
     url: https://github.com/OxfordCompetencyCenters/aicc_chatbot_modules
+    image: https://github.com/OxfordCompetencyCenters.png
     license: CC-BY-4.0
 ---
 

--- a/technology_and_tooling/chatbot_development/m8-01-capstone-project-brief.md
+++ b/technology_and_tooling/chatbot_development/m8-01-capstone-project-brief.md
@@ -1,0 +1,236 @@
+---
+name: Capstone Project Brief
+dependsOn:
+  - technology_and_tooling.chatbot_development.m4-05-user-personalisation
+tags: [chatbots, capstone, project, rag, chromadb, memory, evaluation]
+learningOutcomes:
+  - Define a domain-specific chatbot project with a clear goal and document corpus.
+  - Build an integrated chatbot combining RAG over ChromaDB with conversation memory and auto-summarisation.
+  - Design and execute experiments that evaluate retrieval quality and response quality.
+  - Analyse and report results with quantitative metrics, and reflect on lessons learned.
+attribution:
+  - citation: >
+      Oxford AI Competency Centre (2026). Chatbot Development Course.
+    url: https://github.com/OxfordCompetencyCenters/aicc_chatbot_modules
+    license: CC-BY-4.0
+---
+
+The capstone project is a structured engineering project, not a tutorial exercise. Over Modules 1, 2, and 4 you built individual components — LLM integration and chatbot fundamentals, RAG pipelines backed by a vector database, and conversation memory with summarisation. The capstone brings them together into a single system that solves a real information-retrieval problem for a specific audience. This section defines the project, provides a structured process for executing it, and explains how to evaluate and report your results.
+
+## Project Goal
+
+Build a **domain-specific chatbot** that retrieves information from a curated document corpus, maintains conversation context across turns using auto-summarisation, and runs end-to-end locally as a Streamlit application that users open in a browser.
+
+The emphasis on "domain-specific" is deliberate. A generic chatbot that wraps an LLM API adds little value — users can already access ChatGPT or Claude directly. A domain-specific chatbot adds value by grounding its responses in a particular corpus of documents that the base LLM does not have access to, applying domain-appropriate constraints (what to answer, what to refuse, how to handle ambiguity), and serving a defined audience with specific information needs.
+
+For example, a legal research assistant answers questions grounded in case law documents. A company onboarding bot answers new-hire questions from HR policies and IT setup guides. A medical literature chatbot synthesises findings from PubMed papers. Each solves a problem that a general-purpose LLM cannot solve as well, because the chatbot has access to specialised documents and is tuned for the domain.
+
+Your project should identify a domain, a target audience, and a document corpus, then build a chatbot that serves that audience using that corpus.
+
+## Objectives
+
+The capstone must satisfy the following objectives. Each is testable — you should be able to demonstrate it working.
+
+1. **Retrieval-augmented generation over ChromaDB.** The chatbot ingests a document corpus into a ChromaDB vector store, retrieves relevant chunks at query time, and grounds its responses in those documents. Responses cite or reference the source material rather than relying solely on the LLM's training data.
+
+2. **Conversation memory with auto-summarisation.** The chatbot maintains context across multiple turns within a conversation. A follow-up question like "tell me more about that" correctly refers to the previous response. When the conversation grows beyond a configured threshold, older turns are automatically summarised so the chatbot continues to operate within the model's context window.
+
+3. **Streamlit chat application.** The chatbot runs as a local Streamlit app launched with `streamlit run app.py`. Users interact via a browser: they type messages into a chat input, see the assistant's replies alongside the retrieved source documents, and can reset the session. No containerisation or cloud deployment is required — the app is run locally on the participant's own machine or server.
+
+4. **Documentation.** The project includes a README with setup instructions and usage examples, and at least one Architecture Decision Record for a key technical choice (e.g. ChromaDB as the vector store, or the summarisation strategy).
+
+## Methodology
+
+The project follows a two-phase methodology. Each phase builds on the previous one, and the integration checklist at the end of this section serves as a quality gate to verify completeness before moving forward.
+
+### Phase 1: Domain and Data
+
+Choose a domain and assemble a document corpus. A good domain choice has three properties: the documents are available (you can collect or access them), the questions are non-trivial (they require searching across multiple documents, not just looking up a single fact), and the audience is defined (you can describe who would use this chatbot and what they need).
+
+Prepare the corpus for RAG ingestion. Chunk documents using the strategies from Module 2 — experiment with chunk sizes (500, 1,000, 1,500 tokens) to find the best trade-off between granularity and context. Generate embeddings and store them in a ChromaDB collection on local disk. Verify that similarity search returns relevant results for a sample of test queries before proceeding to the next phase.
+
+### Phase 2: Core Pipeline
+
+Build the end-to-end chat flow: the user sends a message, the RAG engine retrieves relevant documents from ChromaDB, the memory manager supplies prior conversation history (summarising older turns when necessary), the prompt is constructed with the retrieved context and the conversation memory, the LLM generates a response, and the response is returned to the user.
+
+The system has three core components arranged around the LLM:
+
+```
+                ┌────────────────────────┐
+                │   Streamlit UI         │
+                │   (browser chat)       │
+                └───────────┬────────────┘
+                            │ message
+                            ▼
+                ┌────────────────────────┐
+                │      Chatbot Core      │
+                │  (orchestration loop)  │
+                └─────┬─────────────┬────┘
+                      │             │
+          retrieve    │             │   recall / summarise
+                      ▼             ▼
+          ┌───────────────────┐  ┌──────────────────────┐
+          │    RAG Engine     │  │   Memory Manager     │
+          │  (ChromaDB store) │  │  (history + auto-    │
+          │                   │  │   summarisation)     │
+          └─────────┬─────────┘  └──────────┬───────────┘
+                    │  retrieved chunks     │  history + summary
+                    └───────────┬───────────┘
+                                ▼
+                    ┌────────────────────────┐
+                    │       OpenAI LLM       │
+                    │        (chat)          │
+                    └────────────────────────┘
+```
+
+The **Streamlit UI** is the entry point — `st.chat_input` captures each user message and `st.chat_message` renders both the user turn and the assistant's reply (with source references). Session state holds the conversation history between reruns. The **chatbot core** orchestrates each turn. The **RAG engine** owns the ChromaDB collection — ingestion, embedding generation, and similarity search. The **memory manager** owns the conversation history and the summarisation policy: recent turns are kept verbatim, older turns are collapsed into a rolling summary when a configurable turn or token threshold is exceeded. The LLM receives a prompt built from the system instructions, the memory-manager output, the retrieved document chunks, and the new user message.
+
+### Integration Checklist
+
+Use this checklist as a quality gate to verify completeness before you start the experiments.
+
+**Core Functionality:**
+- `streamlit run app.py` launches the chatbot in a browser.
+- The chat input accepts a user message and the assistant's reply renders in the conversation, with visible source references.
+- RAG retrieval fetches relevant documents from ChromaDB for a given query.
+- LLM generation creates responses grounded in the retrieved context.
+- Conversation history persists across reruns via `st.session_state`, and a "Reset conversation" control clears it.
+- API keys are loaded from environment variables (e.g. via `python-dotenv`), not hardcoded.
+
+**Data Flow:**
+- User messages flow through the full pipeline: user input → memory manager → RAG retrieval → prompt assembly → LLM generation → response.
+- Retrieved document chunks are properly formatted and injected into the LLM prompt.
+- Conversation history is stored and retrieved correctly between turns within a session.
+
+**Context Management:**
+- Running a 20-turn conversation does not exceed the model's context window.
+- When the configured threshold is crossed, older turns are collapsed into a rolling summary.
+- A follow-up question such as "tell me more about that" correctly resolves against earlier content — even after summarisation.
+
+### Priority Framework
+
+When time is limited, work through priorities in order. Priority 1 must be complete before moving to Priority 2.
+
+**Priority 1: Core Functionality (Must Have).** End-to-end chat with RAG over ChromaDB and conversation memory with auto-summarisation. This is Phases 1–2.
+
+**Priority 2: Documentation (Important).** README, at least one ADR, and an architecture diagram. Allocate dedicated time for this regardless of progress on other priorities.
+
+## Experiments
+
+Once the system is built, evaluate it systematically. The experiments below assess whether the system meets its objectives.
+
+### Retrieval Quality
+
+Prepare a small set of 5–10 test queries with known answers that exist in your document corpus. For each query, record which documents the RAG engine retrieves and whether the correct document appears in the top-k results. A handful of well-chosen queries is more useful than a large set of shallow ones.
+
+```python
+test_queries = [
+    {"query": "What is the refund policy?", "expected_doc": "returns-policy.md"},
+    {"query": "How do I set up two-factor authentication?", "expected_doc": "security-guide.md"},
+    # ... more test queries
+]
+
+results = []
+for test in test_queries:
+    retrieved = rag_engine.retrieve(test["query"], top_k=5)
+    doc_names = [doc["metadata"]["source"] for doc in retrieved]
+    hit = test["expected_doc"] in doc_names
+    results.append({
+        "query": test["query"],
+        "hit": hit,
+        "top_score": retrieved[0]["score"] if retrieved else 0,
+        "retrieved_docs": doc_names
+    })
+
+hit_rate = sum(r["hit"] for r in results) / len(results)
+print(f"Retrieval hit rate (top-5): {hit_rate:.0%}")
+```
+
+If retrieval quality is poor, the most common causes are chunk size mismatches (try 500, 1,000, and 1,500 tokens), embedding model mismatches (verify the same model is used for documents and queries), and similarity thresholds that are too high or too low.
+
+### Response Quality
+
+For the same test queries, evaluate whether the chatbot's full response correctly answers the question based on the retrieved documents. Check for three failure modes: incorrect answers (the response contradicts the source documents), hallucinated answers (the response includes information not present in any retrieved document), and refusal to answer when the information is available.
+
+Manual evaluation is the most reliable method for a capstone-scale project. For each test query, rate the response as correct, partially correct, or incorrect. If you have reference answers, you can also use an LLM-as-judge approach — ask a separate LLM call to score the response against the reference.
+
+### Robustness
+
+Test how the system handles inputs outside the happy path:
+
+- **Empty input:** Send an empty string. The system should return a helpful prompt, not crash.
+- **Very long input:** Send a message over 1,000 words. The system should truncate or handle it gracefully.
+- **Gibberish:** Send random characters. The system should ask for clarification.
+- **Off-topic queries:** Ask about something completely outside the domain. The system should redirect politely.
+
+Record the result of each test: pass (reasonable response), fail (crash, unhelpful error, or inappropriate response).
+
+### Performance
+
+Measure two simple performance properties:
+
+- **Latency:** Time each of your test queries once and report the average response time. No need for p95/p99 — a mean over 5–10 requests is enough to give a sense of typical latency.
+- **Memory stability:** Run a 20-turn conversation and confirm that token counts stay within the model's context window. This directly tests whether auto-summarisation is working — without it, a long conversation would eventually overflow the window.
+
+```python
+import time
+
+latencies = []
+for test in test_queries:
+    start = time.time()
+    response = chatbot.chat(test["query"])
+    latencies.append(time.time() - start)
+
+print(f"Average latency: {sum(latencies) / len(latencies):.2f}s")
+```
+
+## Results
+
+Document your experimental results in a structured format. Tables are more effective than prose for conveying quantitative data. The numbers below are illustrative — yours will differ. The goal is to *report* your results honestly and clearly, not to hit any particular target.
+
+**Retrieval quality:**
+
+| Metric | Value |
+|--------|-------|
+| Test queries | 8 |
+| Hit rate (top-5) | 6 / 8 |
+
+**Response quality:**
+
+| Rating | Count |
+|--------|-------|
+| Correct | 6 |
+| Partially correct | 1 |
+| Incorrect | 1 |
+
+**Performance:**
+
+| Metric | Value |
+|--------|-------|
+| Average latency (8 requests) | 2.1s |
+| 20-turn conversation fits in context | Pass |
+
+**Robustness:**
+
+| Test case | Result |
+|-----------|--------|
+| Empty input | Pass |
+| Long input (1,000+ words) | Pass |
+| Gibberish | Pass |
+| Off-topic query | Pass |
+
+**Optional baseline (if time allows).** Pick *one* comparison that illustrates the value of an engineering choice you made — for example, retrieval hit rate with two different chunk sizes, or the token count of a 20-turn conversation with auto-summarisation enabled versus disabled. A single well-presented comparison is sufficient.
+
+## Conclusion
+
+The conclusion is a structured reflection on the project. It should address the following:
+
+**What worked well.** Which components performed as expected? Which design decisions proved effective? For example: "The combination of 800-token chunks with cross-encoder re-ranking achieved 85% retrieval accuracy, significantly better than the 60% achieved with default settings."
+
+**What didn't work.** Be specific about failures and their root causes. "The initial summarisation strategy lost important context from early conversation turns. Switching to a hybrid approach (recent turns in full + summary of older turns) resolved this."
+
+**Key technical challenges.** Describe 2–3 significant challenges and how they were resolved. These demonstrate problem-solving ability and depth of understanding.
+
+**Lessons learned.** What would you do differently if starting over? What surprised you about building an LLM application in practice versus in theory?
+
+**Future improvements.** List 3–5 concrete, prioritised improvements. For example: fine-tune a smaller model on domain data to reduce cost and improve accuracy; add function calling so the chatbot can take actions (not just answer questions); implement multi-modal support for image and PDF uploads.

--- a/technology_and_tooling/chatbot_development/m8-02-deliverables-and-documentation.md
+++ b/technology_and_tooling/chatbot_development/m8-02-deliverables-and-documentation.md
@@ -12,6 +12,7 @@ attribution:
   - citation: >
       Oxford AI Competency Centre (2026). Chatbot Development Course.
     url: https://github.com/OxfordCompetencyCenters/aicc_chatbot_modules
+    image: https://github.com/OxfordCompetencyCenters.png
     license: CC-BY-4.0
 ---
 

--- a/technology_and_tooling/chatbot_development/m8-02-deliverables-and-documentation.md
+++ b/technology_and_tooling/chatbot_development/m8-02-deliverables-and-documentation.md
@@ -1,0 +1,331 @@
+---
+name: Deliverables and Documentation
+dependsOn:
+  - technology_and_tooling.chatbot_development.m8-01-capstone-project-brief
+tags: [chatbots, documentation, architecture-decision-records, code-quality, capstone, deliverables]
+learningOutcomes:
+  - Write a professional README that enables someone to understand, install, and use the project in under 15 minutes.
+  - Create Architecture Decision Records that document the rationale behind key technical choices.
+  - Apply code quality standards including type hints, docstrings, and input validation.
+  - Compile and verify a complete set of capstone deliverables covering code, documentation, experimentation, and results.
+attribution:
+  - citation: >
+      Oxford AI Competency Centre (2026). Chatbot Development Course.
+    url: https://github.com/OxfordCompetencyCenters/aicc_chatbot_modules
+    license: CC-BY-4.0
+---
+
+Documentation is how you communicate your project's goal, methodology, results, and conclusions to others. A working chatbot with no documentation is a black box — no one can run it, evaluate it, or build on it. This section covers the documentation standards your capstone should meet, the code quality expectations, and the final submission checklist.
+
+## Writing a Professional README
+
+The README is the front door of your project. A good README answers six questions: What does this project do? How do I install it? How do I use it? How is it structured? How do I contribute? What are its limitations?
+
+The structure below covers these questions:
+
+```markdown
+# [Project Name] - AI-Powered Chatbot
+
+## Overview
+[2-3 sentence description of what your chatbot does and who it's for]
+
+**Key Features:**
+- RAG-powered knowledge retrieval from [domain] documents
+- Conversation memory with auto-summarisation for long sessions
+- Source citations for every answer
+
+**Tech Stack:**
+- Language: Python 3.10
+- Web UI: Streamlit (local browser app)
+- Vector DB: ChromaDB (local, persistent)
+- LLM: OpenAI GPT-3.5-turbo (or equivalent chat model)
+- Embeddings: `text-embedding-3-small` (or sentence-transformers)
+
+## Architecture
+
+[Include your architecture diagram here]
+
+**Core Components:**
+- **Chatbot Core:** Orchestrates each turn — assembles the prompt and calls the LLM.
+- **RAG Engine:** Ingests the document corpus into ChromaDB and retrieves relevant chunks at query time.
+- **Memory Manager:** Maintains conversation history and automatically summarises older turns once a configured threshold is exceeded.
+
+## Quick Start
+
+### Prerequisites
+- Python 3.10+
+- OpenAI API key
+
+### Installation
+
+1. Clone the repository:
+git clone https://github.com/yourusername/your-chatbot.git
+cd your-chatbot
+
+2. Create a virtual environment and install dependencies:
+python -m venv .venv
+source .venv/bin/activate  # or .venv\Scripts\activate on Windows
+pip install -r requirements.txt
+
+3. Set up environment variables:
+cp .env.example .env
+# Edit .env and add your OPENAI_API_KEY
+
+4. Ingest the document corpus into ChromaDB:
+python -m chatbot.ingest --source data/documents
+
+5. Run the chatbot:
+streamlit run app.py
+# then open http://localhost:8501 in your browser
+
+## Usage
+
+Once `streamlit run app.py` is running, open the URL it prints (usually `http://localhost:8501`). You should see:
+
+- A chat input at the bottom of the page.
+- Previous messages rendered as a conversation above the input.
+- A sidebar with a "Reset conversation" button and any configuration toggles (e.g. show retrieved sources).
+
+### Example session
+
+    You: What is the refund policy?
+    Assistant: Refunds are available within 30 days of purchase, provided the item
+               is unused.
+               Sources: returns-policy.md
+
+    You: And for digital products?
+    Assistant: Digital products are non-refundable once downloaded.
+               Sources: returns-policy.md
+
+### Programmatic example (for tests)
+
+    from chatbot import Chatbot
+
+    bot = Chatbot()
+    reply = bot.chat("What is the refund policy?")
+    print(reply.text)
+    print(reply.sources)
+
+## Configuration
+
+### Environment Variables
+- OPENAI_API_KEY: Your OpenAI API key (required)
+- MODEL_NAME: LLM model to use (default: gpt-3.5-turbo)
+- MAX_TOKENS: Max response length (default: 500)
+- CHROMA_DB_PATH: Path to the local ChromaDB persistence directory
+- SUMMARY_THRESHOLD: Number of turns before older history is summarised (default: 10)
+
+## Project Structure
+├── app.py                   # Streamlit entry point
+├── chatbot/
+│   ├── __init__.py
+│   ├── core.py              # Chatbot orchestration (called from app.py)
+│   ├── rag.py               # RAG over ChromaDB
+│   ├── memory.py            # Memory with auto-summarisation
+│   ├── llm.py               # OpenAI client wrapper
+│   └── ingest.py            # Corpus ingestion script
+├── data/
+│   └── documents/           # Source documents
+├── tests/                   # Unit tests
+├── requirements.txt
+├── .env.example
+└── README.md
+
+## Running Tests
+pytest tests/
+
+## Performance
+- Average response time: ~2 seconds per query
+- Cost: ~$0.002 per conversation (average)
+- 20-turn conversations stay within the model's context window via auto-summarisation
+
+## Limitations
+- Only supports English language
+- Document ingestion limited to text and PDF
+- Runs locally on a single machine — no multi-user hosting
+```
+
+The overview communicates what the project does and who it's for. The quick start provides copy-paste commands to get the project running. The example session lets a reader see the chatbot's behaviour without running it themselves. The limitations section demonstrates understanding of the system's boundaries.
+
+Include a `.env.example` file in your repository listing all required environment variables with placeholder values. Never commit actual secrets.
+
+## Architecture Decision Records
+
+An Architecture Decision Record (ADR) documents a significant technical decision: what was decided, why, what alternatives were considered, and what the consequences are. ADRs capture reasoning that would otherwise be lost.
+
+Here is the ADR format:
+
+```markdown
+# ADR 001: Use ChromaDB for Vector Storage
+
+## Context
+Need to store and search document embeddings for RAG. The system will
+initially serve a small to medium document corpus (under 100,000 vectors)
+with potential to grow.
+
+## Decision
+Use ChromaDB for local development and initial production.
+
+## Rationale
+- Simple setup with no separate server required
+- Good performance for small to medium scale (<1M vectors)
+- Free and open-source
+- Easy migration path to Pinecone if scale demands it
+
+## Consequences
+- **Positive:** Fast development cycle, no infrastructure management
+- **Negative:** Limited to single-machine scale
+- **Mitigation:** Plan migration to Pinecone if scale exceeds 500K vectors
+
+## Alternatives Considered
+- Pinecone: Too expensive for MVP stage
+- Weaviate: More complex setup for comparable features
+- FAISS: No persistent storage out of the box
+```
+
+Write at least one ADR for a significant decision — two or three is ideal. Good candidates: vector database choice (ChromaDB), summarisation strategy (when to trigger, what to keep verbatim, what to collapse), chunk size and retrieval top-k, embedding model selection. Place them in a `docs/adr/` directory.
+
+The key to a useful ADR is the "Alternatives Considered" section. It shows the decision was deliberate — you evaluated options and chose the best fit for your constraints.
+
+## Code Quality Standards
+
+Each component should live in its own module: separate files for RAG, memory, LLM integration, and API endpoints. Use clear naming (`get_user_conversation()` not `func1()`). Avoid duplication.
+
+**Code review checklist** before submission:
+
+- No hardcoded secrets (API keys, passwords) anywhere in the codebase
+- No commented-out code (use git history to recover old code)
+- Consistent formatting (use Black for Python)
+- Error handling for all external calls (OpenAI API, ChromaDB, file system)
+- Basic logging for key operations (ingestion, retrieval, summarisation events)
+- Type hints for function signatures
+- Docstrings for public functions
+- No debug print statements in submitted code
+
+The following example demonstrates production-quality Python code:
+
+```python
+def retrieve_relevant_documents(
+    query: str,
+    top_k: int = 5,
+    min_similarity: float = 0.7
+) -> List[Dict[str, Any]]:
+    """
+    Retrieve documents relevant to the query using semantic search.
+
+    Args:
+        query: User's question or search query.
+        top_k: Maximum number of documents to retrieve.
+        min_similarity: Minimum cosine similarity threshold (0-1).
+
+    Returns:
+        List of documents with metadata, sorted by relevance.
+
+    Raises:
+        ValueError: If top_k < 1 or min_similarity not in [0, 1].
+        VectorDBError: If vector database is unreachable.
+    """
+    if top_k < 1:
+        raise ValueError(f"top_k must be >= 1, got {top_k}")
+
+    if not 0 <= min_similarity <= 1:
+        raise ValueError(
+            f"min_similarity must be in [0, 1], got {min_similarity}"
+        )
+
+    try:
+        query_embedding = embedder.embed(query)
+
+        results = vector_db.search(
+            query_embedding,
+            top_k=top_k,
+            filter={"similarity": {"$gte": min_similarity}}
+        )
+
+        logger.info("document_retrieval", extra={
+            "query_length": len(query),
+            "top_k": top_k,
+            "results_found": len(results)
+        })
+
+        return results
+
+    except VectorDBConnectionError as e:
+        logger.error(f"Vector DB connection failed: {e}")
+        raise VectorDBError("Unable to retrieve documents") from e
+```
+
+This demonstrates type hints, a complete docstring, input validation, structured logging, and specific exception handling. Run a linter (pylint or flake8) before submitting. Remove debug print statements. Add missing type hints and docstrings.
+
+## Submission Checklist
+
+Use this checklist as a final quality gate.
+
+**Code:**
+- GitHub repository with all code, public and accessible
+- README.md with setup instructions and usage examples
+- `.env.example` with all required environment variables listed (no actual secrets)
+- `requirements.txt` with pinned dependency versions
+- Ingestion script that populates ChromaDB from the document corpus
+- `app.py` Streamlit entry point that runs the full chat loop in the browser
+
+**Documentation:**
+- Architecture diagram included in the README
+- At least 1 Architecture Decision Record for a key technical choice (2–3 is ideal)
+- Project goal, objectives, and methodology documented
+
+**Experimentation and Results:**
+- Retrieval quality evaluated against a set of test queries with known answers
+- Response quality assessed (correct, partially correct, incorrect)
+- Robustness tested across edge cases (empty input, long input, gibberish, off-topic)
+- Performance benchmarks documented (average latency, 20-turn conversation stays within context)
+- Results presented in tables with quantitative metrics
+- Baseline comparison included where applicable (e.g. with / without RAG, with / without auto-summarisation)
+
+**Reflection:**
+- Conclusion documenting what worked, what didn't, and key challenges
+- Lessons learned and what you would do differently
+- Future improvements listed (concrete and prioritised)
+
+**Optional (strengthens the project):**
+- User testing feedback from real or simulated users
+- Ablation comparing different chunk sizes or summarisation thresholds
+- Video demo of the Streamlit app in use (5–10 minutes)
+
+::::challenge{id=m8-02-final-integration title="Final Integration and Evaluation"}
+
+Work through this exercise in four phases.
+
+**Phase 1: Integration Testing (20 minutes).** Start the Streamlit app with `streamlit run app.py` and verify the end-to-end flow locally. Send a message through the chat input, confirm RAG retrieval over ChromaDB and LLM generation work correctly, and verify the response appears with source citations. Test that conversation memory persists across reruns (Streamlit re-executes the script on every interaction — session state must survive) and that auto-summarisation kicks in once the configured threshold is crossed. Fix any broken connections.
+
+**Phase 2: Run Experiments (30 minutes).** Execute the experiments defined in the project brief. Run your 5–10 test queries through the system and record retrieval hit rates and response quality ratings. Test the robustness scenarios (empty input, gibberish, off-topic, very long input). Record the average latency across those same queries. Run a 20-turn conversation and confirm token counts stay within the model's context window.
+
+**Phase 3: Document Results (20 minutes).** Compile your experimental results into the tables described in the project brief. Write the conclusion: what worked, what didn't, key challenges, lessons learned, and future improvements. Add the results to your project documentation.
+
+**Phase 4: Polish (10 minutes).** Clean up the codebase: remove debug print statements, add missing type hints and docstrings, run a formatter (Black), and verify error messages are helpful. Walk through the submission checklist and check off each item.
+::::
+
+::::challenge{id=m8-02-checkpoint title="Project Checkpoint 8: Complete Capstone"}
+
+Your capstone project should now be complete.
+
+Deliverables:
+
+- All components integrated and working end-to-end locally
+- README with project overview, setup instructions, and architecture diagram
+- At least 1 ADR documenting a key technical decision (2–3 is ideal)
+- Experimental results documented with quantitative metrics
+- Conclusion with reflection on what worked, what didn't, and future improvements
+- Code cleaned up, formatted, and linted
+- Submission checklist completed
+::::
+
+## Additional Resources
+
+- [arXiv](https://arxiv.org/) — Preprint server for AI/ML research papers
+- [OpenAI Blog](https://openai.com/blog) — Updates on models, APIs, and best practices
+- [Anthropic Blog](https://www.anthropic.com/blog) — Research and engineering insights
+- [Hugging Face Blog](https://huggingface.co/blog) — Open-source model releases and tutorials
+- [Fast.ai](https://www.fast.ai/) — Practical deep learning courses
+- [DeepLearning.AI](https://www.deeplearning.ai/) — Specialised AI/ML courses
+- ["Building LLM Applications for Production"](https://huyenchip.com/2023/04/11/llm-engineering.html) by Chip Huyen — Practical LLM production engineering

--- a/technology_and_tooling/index.md
+++ b/technology_and_tooling/index.md
@@ -10,9 +10,10 @@ courses: [
   testing,
   docker,
   snakemake,
+  chatbot_development,
 ]
 summary: |
-  Basic tools like bash, version control, containers, IDEs, and snakemake.
+  Basic tools like bash, version control, containers, IDEs, and snakemake; plus an applied AI course on building chatbots with Large Language Models.
 ---
 
-Basic tools like bash, version control, containers, IDEs, and snakemake.
+Basic tools like bash, version control, containers, IDEs, and snakemake; plus an applied AI course on building chatbots with Large Language Models.


### PR DESCRIPTION
New applied AI course authored by the Oxford AI Competency Centre. Content covers:

- Module 1 (4 lessons): Chatbot foundations and OpenAI API integration
- Module 2 (5 lessons): RAG with vector embeddings and ChromaDB
- Module 3 (5 lessons): Advanced RAG - agentic retrieval, reranking, hybrid search, knowledge graphs, semantic caching, evaluation
- Module 4 (5 lessons): Memory and context management including auto-summarisation and retrieval-based memory
- Modules 5-7 (15 lessons, tagged 'optional'): Deployment, analytics, and production-hardening topics for self-paced study
- Module 8 (2 lessons): Streamlit-based capstone project brief and deliverables/documentation guide

Frontmatter uses the standard course-material schema (name, id, dependsOn with dotted paths, tags, learningOutcomes, attribution). Exercises are wrapped in `:::challenge` directives where the source contained explicit exercise sections. Runnable notebooks and the Streamlit capstone scaffold live in the companion repository at https://github.com/OxfordCompetencyCenters/aicc_chatbot_modules and are linked from each lesson's "Hands-on practical" section.

Also adds chatbot_development to the courses list in technology_and_tooling/index.md.