### PR TITLE
Enforce ascii only code blocks

### DIFF
--- a/.github/scripts/check_ascii_codeblocks.py
+++ b/.github/scripts/check_ascii_codeblocks.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""Fail if any fenced code block in the repo's Markdown files contains
+non-ASCII characters, unless the block opts out with an `allow-non-ascii`
+flag in its opening fence info string, e.g.:
+
+    ```python allow-non-ascii
+    name = "café"
+    ```
+
+`text` and `output` blocks are exempt, since they typically hold captured
+terminal output or illustrative pseudocode rather than real code.
+"""
+
+import re
+import subprocess
+import sys
+
+FENCE_RE = re.compile(r"^( {0,3})(`{3,}|~{3,})(.*)$")
+OPT_OUT_FLAG = "allow-non-ascii"
+EXEMPT_LANGUAGES = {"text", "output"}
+
+
+def list_markdown_files() -> list[str]:
+    result = subprocess.run(
+        ["git", "ls-files", "*.md"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return [line for line in result.stdout.splitlines() if line]
+
+
+def find_violations(path: str) -> list[str]:
+    violations = []
+
+    with open(path, encoding="utf-8") as f:
+        lines = f.readlines()
+
+    in_block = False
+    fence_char = ""
+    fence_len = 0
+    fence_lineno = 0
+    skip_block = False
+    lang = ""
+
+    for lineno, raw_line in enumerate(lines, start=1):
+        line = raw_line.rstrip("\n")
+        match = FENCE_RE.match(line)
+
+        if not in_block:
+            if match:
+                fence_char = match.group(2)[0]
+                fence_len = len(match.group(2))
+                fence_lineno = lineno
+                tokens = match.group(3).strip().split()
+                lang = tokens[0].lower() if tokens else "(none)"
+                skip_block = lang in EXEMPT_LANGUAGES or OPT_OUT_FLAG in tokens[1:]
+                in_block = True
+            continue
+
+        # Inside a block: check for a closing fence first.
+        if match and match.group(2)[0] == fence_char and len(match.group(2)) >= fence_len and not match.group(3).strip():
+            in_block = False
+            continue
+
+        if skip_block:
+            continue
+
+        for col, char in enumerate(line, start=1):
+            if ord(char) > 127:
+                violations.append(
+                    f"{path}:{lineno}:{col}: non-ASCII character {char!r} "
+                    f"(U+{ord(char):04X}) in fenced code block opened at "
+                    f"{path}:{fence_lineno} (lang={lang}). "
+                    f"If deliberate, add `{OPT_OUT_FLAG}` to that fence, "
+                    f"e.g. ```{lang} {OPT_OUT_FLAG}"
+                )
+
+    return violations
+
+
+def main() -> int:
+    all_violations = []
+    for path in list_markdown_files():
+        all_violations.extend(find_violations(path))
+
+    if all_violations:
+        print("Non-ASCII characters found in fenced code blocks:\n")
+        for violation in all_violations:
+            print(violation)
+        print(f"\n{len(all_violations)} violation(s) found.")
+        return 1
+
+    print("No non-ASCII characters found in fenced code blocks.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -36,6 +36,21 @@ jobs:
           directory: "."
           language: "python"
 
+  check-ascii-codeblocks:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+
+      - name: Check code blocks for non-ASCII characters
+        run: python3 .github/scripts/check_ascii_codeblocks.py
+
   lint-markdown:
     runs-on: ubuntu-latest
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -216,7 +216,7 @@ Used to summarise the most essential or critical information in a topic. These c
 
 ## Linting
 
-There are 3 linting actions that are run on the material in this repo, these are:
+There are 4 linting actions that are run on the material in this repo, these are:
 
 ### Front matter
 
@@ -238,6 +238,20 @@ Python code is checked using a custom action, this works by stitching all python
 There is no command line tool for this, so it can only be run locally with `act`.
 
 There are no corresponding tools for other languages, e.g. C++, due to difficulties in stitching together a non-interpreted language.
+
+### Non-ASCII characters
+
+Fenced code blocks are checked for stray non-ASCII characters (e.g. curly quotes or invisible unicode pasted in by accident), since these can silently break example code. `text` and `output` blocks are exempt, as they usually hold captured terminal output rather than real code. If a block deliberately needs a non-ASCII character, add `allow-non-ascii` to its opening fence:
+
+```python allow-non-ascii
+name = "café"
+```
+
+Run the check manually with:
+
+```bash
+python3 .github/scripts/check_ascii_codeblocks.py
+```
 
 ## Link-checking
 

--- a/ai_tooling/careful_coding_with_copilots/02_ode_simulation_and_inference.md
+++ b/ai_tooling/careful_coding_with_copilots/02_ode_simulation_and_inference.md
@@ -391,7 +391,7 @@ for i in range(0, 3):
         score = best_error
         params = best_params
 
-return params  # outside the loop — returns the best result across all repeats
+return params  # outside the loop - returns the best result across all repeats
 ```
 
 :::

--- a/high_performance_computing/hpc_mpi/05_collective_communication.md
+++ b/high_performance_computing/hpc_mpi/05_collective_communication.md
@@ -433,7 +433,7 @@ int MPI_Allreduce(
     int count,              
     MPI_Datatype datatype,  
     MPI_Op op,              
-    MPI_Comm comm           
+    MPI_Comm comm           
 );
 ```
 

--- a/high_performance_computing/hpc_mpi/10_communication_patterns.md
+++ b/high_performance_computing/hpc_mpi/10_communication_patterns.md
@@ -93,7 +93,7 @@ Since each point generated and its position within the circle is completely inde
 the communication pattern is simple (this is also an example of an embarrassingly parallel problem) as we only need one reduction.
 To parallelise the problem, each rank generates a sub-set of the total number of points and a reduction is done at the end, to calculate the total number of points within the circle from the entire sample.
 
-```c
+```c allow-non-ascii
 // 1 billion points is a lot, so we should parallelise this calculation
 int total_num_points = (int)1e9;
 

--- a/scientific_computing/ode_solvers/02-PM.md
+++ b/scientific_computing/ode_solvers/02-PM.md
@@ -97,7 +97,7 @@ from matplotlib import pyplot as plt
 from scipy.integrate import odeint
 import numpy as np
 import matplotlib.pyplot as plt
-# Function to solve dxdt=tˆ2/x.
+# Function to solve dxdt=t^2/x.
 def dxdtfor2dsolver(u, t):
     # dxdt=t*t/x (dydt is unused)
     return (t*t/u[0], 0)

--- a/scientific_computing/optimisation/06-nelder-mead.md
+++ b/scientific_computing/optimisation/06-nelder-mead.md
@@ -142,7 +142,7 @@ def nelder_mead(f, x0, tol=1e-5, max_iter=1000):
             vertices[i, i-1] += 0.05
 
     saved_vertices = np.empty([n+1, n, max_iter], dtype=x0.dtype)
-    # Nelder–Mead algorithm from:
+    # Nelder-Mead algorithm from:
     #    Numerical optimization
     #    by Nocedal, Jorge; Wright, Stephen J., 1960-,
     #    Chapter 9

--- a/technology_and_tooling/unit_testing/unit_testing_python.md
+++ b/technology_and_tooling/unit_testing/unit_testing_python.md
@@ -168,7 +168,7 @@ At this point, commit the changes to your testing code:
 
 ```shell
 git add tests/test_models.py
-git commit -m “Added more tests”
+git commit -m "Added more tests"
 git push
 ```
 


### PR DESCRIPTION
See #271

## Summary

- Add a CI check that scans all fenced code blocks in markdown files for non-ASCII characters and fails the build if any are found.
- `text`/`output` blocks are exempt (captured terminal output); any block can opt out with an `allow-non-ascii` flag on its opening fence.
- Fixed 6 pre-existing accidental non-ASCII characters the check caught (curly quotes, a stray non-breaking space, mis-typed circumflex, em/en-dashes) that could have broken copy-pasted commands/code.
- Documented the check and opt-out syntax in CONTRIBUTING.md.