### PR TITLE
Fix typos 'worklow'

### DIFF
--- a/software_project_management/collaboration/workflows.md
+++ b/software_project_management/collaboration/workflows.md
@@ -1,5 +1,5 @@
 ---
-name: Collaborative Worklow
+name: Collaborative Workflow
 dependsOn: [software_project_management.collaboration.issues]
 tags: [github]
 learningOutcomes:


### PR DESCRIPTION
This PR fixes a typos in the collaborative workflow module, which is at the title. 

I spotted this when I was showing a friend of mine the interface of the training material via Google search, and this came up quite high in the search results... so better fix it.